### PR TITLE
Fix compilation errors

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1353,7 +1353,7 @@ void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) {
         SyncTransaction(ptx);
     }
     for (const ReferralRef& pref : pblock->m_vRef) {
-        SyncRefTransaction(ptx);
+        SyncRefTransaction(pref);
     }
 }
 
@@ -1761,7 +1761,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool f
                 for (size_t posInBlock = 0; posInBlock < block.vtx.size(); ++posInBlock) {
                     AddToWalletIfInvolvingMe(block.vtx[posInBlock], pindex, posInBlock, fUpdate);
                 }
-                for (size_t posInBlock = 0; pisInBlock < block.m_vRef.size(); ++posInBlock) {
+                for (size_t posInBlock = 0; posInBlock < block.m_vRef.size(); ++posInBlock) {
                     // Add referral transaction to map
                 }
             } else {
@@ -3433,8 +3433,6 @@ void CWallet::LoadReferral(int64_t nIndex, const Referral& referral)
     AssertLockHeld(cs_wallet);
 
     m_setReferralKeyPool.insert(nIndex);
-
-    CKeyID keyID = referral.m_pubKeyId;
 }
 
 bool CWallet::TopUpKeyPool(unsigned int kpSize, std::shared_ptr<uint256> referredBy, bool outReferral)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1186,6 +1186,7 @@ public:
 
     bool SetReferralTx(const ReferralTx& rtx);
     ReferralRef GenerateNewReferral(CPubKey& pubkey, uint256 referredBy, CWalletDB& walletdb);
+    void ReferralAddedToMempool(const ReferralRef& pref);
 
     bool IsReferred() const;
 };


### PR DESCRIPTION
```
wallet/wallet.cpp:1323:15: error: out-of-line definition of 'ReferralAddedToMempool' does not match any declaration in 'CWallet'
void CWallet::ReferralAddedToMempool(const ReferralRef& pref) {
              ^~~~~~~~~~~~~~~~~~~~~~
wallet/wallet.cpp:1356:28: error: use of undeclared identifier 'ptx'
        SyncRefTransaction(ptx);
                           ^
wallet/wallet.cpp:1764:45: error: use of undeclared identifier 'pisInBlock'; did you mean 'posInBlock'?
                for (size_t posInBlock = 0; pisInBlock < block.m_vRef.size(); ++posInBlock) {
                                            ^~~~~~~~~~
                                            posInBlock
wallet/wallet.cpp:1764:29: note: 'posInBlock' declared here
                for (size_t posInBlock = 0; pisInBlock < block.m_vRef.size(); ++posInBlock) {
                            ^
wallet/wallet.cpp:3437:12: warning: unused variable 'keyID' [-Wunused-variable]
    CKeyID keyID = referral.m_pubKeyId;
```