### PR TITLE
Make sure to clear proof of work if it fails before retry.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -52,6 +52,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
 
         uint32_t nMaxTries = 10000000;
         while (nMaxTries > 0 && !cuckoo::FindProofOfWork(genesis.GetHash(), genesis.nBits, pow, params)) {
+            pow.clear();
             ++genesis.nNonce;
             --nMaxTries;
         }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -136,6 +136,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
         while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !cuckoo::FindProofOfWork(pblock->GetHash(), pblock->nBits, cycle, consensusParams)) {
+            cycle.clear();
             ++pblock->nNonce;
             --nMaxTries;
         }


### PR DESCRIPTION
Not clearing causes an assert failure

    meritd: cuckoo/miner.cpp:20: bool cuckoo::FindProofOfWork(uint256, unsigned int, std::set<unsigned int>&, const Consensus::Params&): Assertion `cycle.empty()' failed

because sometimes a cycle is found but doesn't satisfy the requirements. We need to clear the output before trying again.