### PR TITLE
Tides go in, tides go out, can't explain that.

### DIFF
--- a/src/cuckoo/mean_cuckoo.cpp
+++ b/src/cuckoo/mean_cuckoo.cpp
@@ -260,7 +260,7 @@ void matchworker(solver_ctx<offset_t, EDGEBITS, XBITS>* solver, uint32_t id)
 }
 
 template <uint8_t EDGEBITS, uint8_t XBITS>
-using zbucket8 = uint8_t[2 * Params<EDGEBITS, XBITS>::NYZ1];
+using zbucket8 = uint8_t[2 * Params<EDGEBITS, XBITS>::NZ];
 
 template <uint8_t EDGEBITS, uint8_t XBITS>
 using zbucket16 = uint16_t[Params<EDGEBITS, XBITS>::NTRIMMEDZ];


### PR DESCRIPTION
Fix segfault on linux. trimrename went passed end of array per thread
causing segfault. Resized array to be expected size.