### PR TITLE
Set chainwork to actual genesis block work for mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -217,7 +217,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_GENESIS].nTimeout = 1230767999;   // December 31, 2008
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000723d3581fe1bd55373540a");
+        consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000002");
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x0000000000000000003b9ce759c2a087d52abc4266f8f4ebd6d768b89defa50a"); //477890


### PR DESCRIPTION
For now let's set it to this value (actual value for genesis `nBits`). after testing we need to update both `nBits` and `nMinimumChainWork`