### PR TITLE
Meritd does not compile with recent boost on OSX

### DIFF
--- a/src/mempool.h
+++ b/src/mempool.h
@@ -105,7 +105,7 @@ template <typename T>
 class CompareMemPoolEntryByEntryTime
 {
 public:
-    bool operator()(const MemPoolEntry<T>& a, const MemPoolEntry<T>& b)
+    bool operator()(const MemPoolEntry<T>& a, const MemPoolEntry<T>& b) const
     {
         return a.GetTime() < b.GetTime();
     }

--- a/src/miner.h
+++ b/src/miner.h
@@ -81,7 +81,7 @@ struct modifiedentry_iter {
 // except operating on CTxMemPoolModifiedEntry.
 // TODO: refactor to avoid duplication of this logic.
 struct CompareModifiedEntry {
-    bool operator()(const CTxMemPoolModifiedEntry &a, const CTxMemPoolModifiedEntry &b)
+    bool operator()(const CTxMemPoolModifiedEntry &a, const CTxMemPoolModifiedEntry &b) const
     {
         double f1 = (double)a.nModFeesWithAncestors * b.nSizeWithAncestors;
         double f2 = (double)b.nModFeesWithAncestors * a.nSizeWithAncestors;
@@ -96,7 +96,7 @@ struct CompareModifiedEntry {
 // This is sufficient to sort an ancestor package in an order that is valid
 // to appear in a block.
 struct CompareTxIterByAncestorCount {
-    bool operator()(const CTxMemPool::txiter &a, const CTxMemPool::txiter &b)
+    bool operator()(const CTxMemPool::txiter &a, const CTxMemPool::txiter &b) const
     {
         if (a->GetCountWithAncestors() != b->GetCountWithAncestors())
             return a->GetCountWithAncestors() < b->GetCountWithAncestors();

--- a/src/refmempool.h
+++ b/src/refmempool.h
@@ -59,7 +59,7 @@ private:
 class CompareRefMemPoolEntryByDescendantsCount
 {
 public:
-    bool operator()(const RefMemPoolEntry& a, const RefMemPoolEntry& b)
+    bool operator()(const RefMemPoolEntry& a, const RefMemPoolEntry& b) const
     {
         double f1 = (double)a.GetCountWithDescendants();
         double f2 = (double)b.GetCountWithDescendants();

--- a/src/sync.h
+++ b/src/sync.h
@@ -129,10 +129,10 @@ private:
 
     bool TryEnter(const char* pszName, const char* pszFile, int nLine)
     {
-        EnterCritical(pszName, pszFile, nLine, (void*)(lock.mutex()), true);
+        ::EnterCritical(pszName, pszFile, nLine, (void*)(lock.mutex()), true);
         lock.try_lock();
         if (!lock.owns_lock())
-            LeaveCritical();
+            ::LeaveCritical();
         return lock.owns_lock();
     }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -187,7 +187,7 @@ private:
 class CompareTxMemPoolEntryByDescendantScore
 {
 public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
         bool fUseADescendants = UseDescendantScore(a);
         bool fUseBDescendants = UseDescendantScore(b);
@@ -209,7 +209,7 @@ public:
     }
 
     // Calculate which score to use for an entry (avoiding division).
-    bool UseDescendantScore(const CTxMemPoolEntry &a)
+    bool UseDescendantScore(const CTxMemPoolEntry &a) const
     {
         double f1 = (double)a.GetModifiedFee() * a.GetSizeWithDescendants();
         double f2 = (double)a.GetModFeesWithDescendants() * a.GetSize();
@@ -224,7 +224,7 @@ public:
 class CompareTxMemPoolEntryByScore
 {
 public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
         double f1 = (double)a.GetModifiedFee() * b.GetSize();
         double f2 = (double)b.GetModifiedFee() * a.GetSize();
@@ -238,7 +238,7 @@ public:
 class CompareTxMemPoolEntryByAncestorFee
 {
 public:
-    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b)
+    bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
         double aFees = a.GetModFeesWithAncestors();
         double aSize = a.GetSizeWithAncestors();


### PR DESCRIPTION
This fixes compatibility with boost 1.66

Originally found in bitcoin code, adapted for our codebase, refs https://github.com/bitcoin/bitcoin/pull/11847