### PR TITLE
Use native architecture to enable AVX2 if it's available on the hardw…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -227,11 +227,11 @@ AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 if test "x$enable_debug" = xyes; then
     CPPFLAGS="$CPPFLAGS -DDEBUG -DDEBUG_LOCKORDER"
     if test "x$GCC" = xyes; then
-        CFLAGS="$CFLAGS -g3 -O0"
+        CFLAGS="$CFLAGS -march=native -g3 -O0"
     fi
 
     if test "x$GXX" = xyes; then
-        CXXFLAGS="$CXXFLAGS -g3 -O0"
+        CXXFLAGS="$CXXFLAGS -march=native -g3 -O0"
     fi
 fi
 
@@ -264,7 +264,6 @@ fi
 # be compiled with them, rather that specific objects/libs may use them after checking for runtime
 # compatibility.
 AX_CHECK_COMPILE_FLAG([-msse4.2],[[SSE42_CXXFLAGS="-msse4.2"]],,[[$CXXFLAG_WERROR]])
-AX_CHECK_COMPILE_FLAG([-mavx2],[[AVX2_CXXFLAGS="-mavx2"]],,[[$CXXFLAG_WERROR]])
 
 TEMP_CXXFLAGS="$CXXFLAGS"
 TEMP_CXXFLAGS="$TEMP_CXXFLAGS $SSE42_CXXFLAGS"

--- a/src/cuckoo/mean_cuckoo.cpp
+++ b/src/cuckoo/mean_cuckoo.cpp
@@ -40,10 +40,20 @@
 // and directly count YZ values in a cache friendly 32KB.
 // A final pair of compression rounds remap YZ values from 15 into 11 bits.
 
+#ifdef __AVX2__
+
+#ifndef NSIPHASH
+#define NSIPHASH 8
+#endif
+
+#else
 
 #ifndef NSIPHASH
 #define NSIPHASH 1
 #endif
+
+#endif
+
 
 // for p close to 0, Pr(X>=k) < e^{-n*p*eps^2} where k=n*p*(1+eps)
 // see https://en.wikipedia.org/wiki/Binomial_distribution#Tail_bounds


### PR DESCRIPTION
…are.

AVX2 was turned on even on a machine that did not support AVX2 instructions
causing an Illegal Instruction exception when you turned on mining.

This fix let's GCC set the flags based on the native architecture.