### PR TITLE
Update windows build docs

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -94,7 +94,7 @@ Ubuntu Trusty 14.04:
 Ubuntu Xenial 16.04 and Windows Subsystem for Linux <sup>[1](#footnote1),[2](#footnote2)</sup>:
 
     sudo apt install software-properties-common
-    sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu zesty universe"
+    sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu artful universe"
     sudo apt-get update
     sudo apt-get upgrade
     sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -99,7 +99,7 @@ Ubuntu Xenial 16.04 and Windows Subsystem for Linux <sup>[1](#footnote1),[2](#fo
     sudo apt-get upgrade
     sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
 
-Ubuntu Zesty 17.04 <sup>[2](#footnote2)</sup>:
+Ubuntu Zesty 17.04 and Artful 17.10 <sup>[2](#footnote2)</sup>:
 
     sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
 
@@ -119,7 +119,7 @@ To build executables for Windows 32-bit, install the following dependencies:
 
     sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev
 
-For Ubuntu Xenial 16.04, Ubuntu Zesty 17.04 and Windows Subsystem for Linux <sup>[2](#footnote2)</sup>:
+For Ubuntu Xenial 16.04, Ubuntu Zesty 17.04, Artful 17.10 and Windows Subsystem for Linux <sup>[2](#footnote2)</sup>:
 
     sudo update-alternatives --config i686-w64-mingw32-g++  # Set the default mingw32 g++ compiler option to posix.
 


### PR DESCRIPTION
End of life for Ubuntu 17.04 was January 13, 2018.
Now we can fetch same packages from Ubuntu 17.10 repositories.