### PR TITLE
Fix compiler error in referralrecord (OSX/clang)

### DIFF
--- a/src/qt/referralrecord.cpp
+++ b/src/qt/referralrecord.cpp
@@ -58,7 +58,7 @@ ReferralRecord DecomposeReferral(const referral::ReferralRef ref, uint64_t time_
     assert(ref);
 
     const CMeritAddress meritAddress{ref->addressType, ref->GetAddress()};
-    return ReferralRecord{ref->GetHash(), time_received, meritAddress.ToString(), ref->alias};
+    return ReferralRecord{ref->GetHash(), static_cast<qint64>(time_received), meritAddress.ToString(), ref->alias};
 }
 
 /*


### PR DESCRIPTION
```
qt/referralrecord.cpp:61:43: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'qint64' (aka 'long long') in initializer list [-Wc++11-narrowing]
```