### PR TITLE
Fix miner packages

### DIFF
--- a/src/mempool.h
+++ b/src/mempool.h
@@ -102,6 +102,13 @@ struct CompareIteratorByHash {
         return a->GetSharedEntryValue()->GetHash() < b->GetSharedEntryValue()->GetHash();
     }
 };
+template <typename iter>
+struct CompareIteratorByEntryTime {
+    bool operator()(const iter& a, const iter& b) const
+    {
+        return a->GetTime() < b->GetTime();
+    }
+};
 
 template <typename T>
 class CompareMemPoolEntryByEntryTime

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -365,32 +365,23 @@ void BuildConfirmationSet(const CTxMemPool::setEntries& testSet, ConfirmationSet
 
 bool BlockAssembler::CheckReferrals(
         CTxMemPool::setEntries& testSet,
-        referral::ReferralTxMemPool::setEntries& candidateReferrals)
+        referral::ReferralRefs& candidate_referrals)
 {
-    std::vector<referral::ReferralRef> vRefs(candidateReferrals.size());
-
-    std::transform(candidateReferrals.begin(), candidateReferrals.end(), vRefs.begin(),
-        [](const referral::ReferralTxMemPool::RefIter& entryit) {
-            return entryit->GetSharedEntryValue();
-        });
-
     ConfirmationSet confirmations;
     BuildConfirmationSet(txsInBlock, confirmations);
     BuildConfirmationSet(testSet, confirmations);
 
     // test all referrals are signed
-    for (const auto& entryit: candidateReferrals) {
-        const auto referral = entryit->GetEntryValue();
-
-        if (!CheckReferralSignature(referral)) {
+    for (const auto& referral: candidate_referrals) {
+        if (!CheckReferralSignature(*referral)) {
             return false;
         }
 
         if (pblock->IsDaedalus()) {
             // Check package for confirmation for give referral
-            if (confirmations.count(referral.GetAddress()) == 0) {
+            if (confirmations.count(referral->GetAddress()) == 0) {
                 debug("WARNING: Referral confirmation not found: %s",
-                        CMeritAddress{referral.addressType, referral.GetAddress()}.ToString());
+                        CMeritAddress{referral->addressType, referral->GetAddress()}.ToString());
                 return false;
             }
         }
@@ -401,7 +392,7 @@ bool BlockAssembler::CheckReferrals(
         const auto tx = it->GetEntryValue();
 
         CValidationState dummy;
-        if (!Consensus::CheckTxOutputs(tx, dummy, *prefviewcache, vRefs)) {
+        if (!Consensus::CheckTxOutputs(tx, dummy, *prefviewcache, candidate_referrals)) {
             return false;
         }
     }
@@ -426,7 +417,7 @@ bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost
 // - serialized size (in case -blockmaxsize is in use)
 bool BlockAssembler::TestPackageContent(
         const CTxMemPool::setEntries& transactions,
-        const referral::ReferralTxMemPool::setEntries& referrals)
+        const referral::ReferralRefs& referrals)
 {
     uint64_t nPotentialBlockSize = nBlockSize; // only used with fNeedSizeAccounting
     for (const CTxMemPool::txiter it : transactions) {
@@ -451,12 +442,8 @@ bool BlockAssembler::TestPackageContent(
     }
 
     if (fNeedSizeAccounting) {
-        for (const auto& it : referrals) {
-
-            uint64_t nRefSize =
-                ::GetSerializeSize(
-                    it->GetEntryValue(),
-                    SER_NETWORK, PROTOCOL_VERSION);
+        for (const auto& it: referrals) {
+            uint64_t nRefSize = ::GetSerializeSize(*it, SER_NETWORK, PROTOCOL_VERSION);
 
             // share block size by transactions and referrals
             if (nPotentialBlockSize + nRefSize >= nBlockMaxSize) {
@@ -583,7 +570,7 @@ void BlockAssembler::SortForBlock(
     // transactions for block inclusion.
     sortedEntries.clear();
     sortedEntries.insert(sortedEntries.begin(), package.begin(), package.end());
-    std::sort(sortedEntries.begin(), sortedEntries.end(), CompareTxIterByAncestorCount());
+    std::sort(sortedEntries.begin(), sortedEntries.end(), CompareIteratorByEntryTime<CTxMemPool::txiter>());
 }
 
 void BlockAssembler::AddReferrals()
@@ -641,6 +628,53 @@ void BlockAssembler::AddReferrals()
 
         ++nBlockRef;
     }
+}
+
+bool BlockAssembler::GetCandidatePacakageReferrals(
+    const SetRefEntries& package_referrals,
+    referral::ReferralRefs& candidate_referrals)
+{
+    std::set<referral::ReferralRef> candidate_in_block_referrals;
+
+    // get referrals in already added to block and referrals from current package
+    // to one set to skip duplicates
+    std::transform(refsInBlock.begin(), refsInBlock.end(),
+        std::inserter(candidate_in_block_referrals, candidate_in_block_referrals.end()),
+        [](const referral::ReferralTxMemPool::RefIter& entryit) {
+            return entryit->GetSharedEntryValue();
+        });
+
+    std::transform(package_referrals.begin(), package_referrals.end(),
+        std::inserter(candidate_in_block_referrals, candidate_in_block_referrals.end()),
+        [](const referral::ReferralTxMemPool::RefIter& entryit) {
+            return entryit->GetSharedEntryValue();
+        });
+
+    // move referrals from set to vector and build referral tree
+    // of the current candidate block
+    referral::ReferralRefs sorted_referrals;
+    sorted_referrals.insert(
+        sorted_referrals.begin(),
+        candidate_in_block_referrals.begin(),
+        candidate_in_block_referrals.end());
+
+    // if we couldn't build a tree this txs/refs package assumed invalid
+    if (!prefviewdb->OrderReferrals(sorted_referrals)) {
+        return false;
+    }
+
+    for (const auto& referral: sorted_referrals) {
+        auto ref_iter = mempoolReferral.mapRTx.find(referral->GetHash());
+        assert(ref_iter != mempoolReferral.mapRTx.end());
+
+        // add to resulting vector if referral found both in candidate block
+        // and current referrals package
+        if (package_referrals.count(ref_iter) > 0) {
+            candidate_referrals.push_back(referral);
+        }
+    }
+
+    return true;
 }
 
 // This transaction selection algorithm orders the mempool based
@@ -776,15 +810,19 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
             onlyUnconfirmed(ancestors);
         }
 
-        // Test if all tx's have required referrals and all tx's are Final
-        if (!CheckReferrals(ancestors, referrals) || !TestPackageContent(ancestors, referrals)) {
+        referral::ReferralRefs cadidate_referrals;
+
+        // Test if referrals tree is valid, all tx's have required referrals
+        // and all tx's are Final
+        if (!GetCandidatePacakageReferrals(referrals, cadidate_referrals) ||
+            !CheckReferrals(ancestors, cadidate_referrals) ||
+            !TestPackageContent(ancestors, cadidate_referrals)) {
             if (fUsingModified) {
                 mapModifiedTx.get<ancestor_score>().erase(modit);
                 failedTx.insert(iter);
             }
             continue;
         }
-
         // This transaction will make it in; reset the failed counter.
         nConsecutiveFailed = 0;
 
@@ -798,7 +836,14 @@ void BlockAssembler::addPackageTxs(int& nPackagesSelected, int& nDescendantsUpda
             mapModifiedTx.erase(it);
         }
 
-        for (const auto& it : referrals) {
+        std::vector<referral::ReferralTxMemPool::RefIter> sorted_referral_entries;
+
+        std::transform(cadidate_referrals.begin(), cadidate_referrals.end(), std::back_inserter(sorted_referral_entries),
+            [](const referral::ReferralRef& referral) {
+                return mempoolReferral.mapRTx.find(referral->GetHash());
+            });
+
+        for (const auto& it: sorted_referral_entries) {
             AddReferralToBlock(it);
         }
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -139,6 +139,7 @@ struct update_for_parent_inclusion
     CTxMemPool::txiter iter;
 };
 
+using SetRefEntries = referral::ReferralTxMemPool::setEntries;
 /** Generate a new block, without valid proof-of-work */
 class BlockAssembler
 {
@@ -162,7 +163,7 @@ private:
     uint64_t nBlockSigOpsCost;
     CAmount nFees;
     CTxMemPool::setEntries txsInBlock;
-    referral::ReferralTxMemPool::setEntries refsInBlock;
+    SetRefEntries refsInBlock;
 
     // Chain context for the block
     int nHeight;
@@ -210,14 +211,14 @@ private:
      * in a chain or in candidateReferrals.
      * If it's not, skip current package
      */
-    bool CheckReferrals(CTxMemPool::setEntries& testSet, referral::ReferralTxMemPool::setEntries& candidateReferrals);
+    bool CheckReferrals(CTxMemPool::setEntries& testSet, referral::ReferralRefs& candidate_referrals);
     /** Test if a new package would "fit" in the block */
     bool TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const;
     /** Perform checks on each transaction in a package:
       * locktime, premature-witness, serialized size (if necessary)
       * These checks should always succeed, and they're here
       * only as an extra check in case of suboptimal node configuration */
-    bool TestPackageContent(const CTxMemPool::setEntries& transactions, const referral::ReferralTxMemPool::setEntries& referrals);
+    bool TestPackageContent(const CTxMemPool::setEntries& transactions, const referral::ReferralRefs& referrals);
     /** Return true if given transaction from mapTx has already been evaluated,
       * or if the transaction's cached data in mapTx is incorrect. */
     bool SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx);
@@ -227,6 +228,8 @@ private:
       * state updated assuming given transactions are txsInBlock. Returns number
       * of updated descendants. */
     int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx);
+    /** Get vector of sorted current package referrals */
+    bool GetCandidatePacakageReferrals(const SetRefEntries& package_referrals, referral::ReferralRefs& sorted_referrals);
 };
 
 /** Modify the extranonce in a block */

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -354,6 +354,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             "getblocktemplate ( TemplateRequest )\n"
             "\nIf the request parameters include a 'mode' key, that is used to explicitly select between the default 'template' request or a 'proposal'.\n"
             "It returns data needed to construct a block to work on.\n"
+            "Wallet is required to generate valid coinbase that can take part in lottery.\n"
+            "Otherwise assebmled block won't pass validation.\n"
             "For full specification, see BIPs 22, 23, 9, and 145:\n"
             "    https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki\n"
             "    https://github.com/bitcoin/bips/blob/master/bip-0023.mediawiki\n"
@@ -552,30 +554,35 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     }
 
     // Update block
-    static CBlockIndex* pindexPrev;
+    static CBlockIndex* pindexPrev = chainActive.Tip();
     static int64_t nStart;
     static std::unique_ptr<CBlockTemplate> pblocktemplate;
-    // Cache whether the last invocation was with segwit support, to avoid returning
-    // a segwit-block to a non-segwit caller.
-    if (pindexPrev != chainActive.Tip() ||
-        (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
+    if ((mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
     {
-        // Clear pindexPrev so future calls make a new block, despite any failures from here on
-        pindexPrev = nullptr;
-
         // Store the pindexBest used before CreateNewBlock, to avoid races
         nTransactionsUpdatedLast = mempool.GetTransactionsUpdated();
-        CBlockIndex* pindexPrevNew = chainActive.Tip();
         nStart = GetTime();
 
         // Create new block
-        CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = BlockAssembler(Params()).CreateNewBlock(scriptDummy);
+
+#ifdef ENABLE_WALLET
+        const auto pwallet = GetWalletForJSONRPCRequest(request);
+        // check that wallet is alredy referred or has unlock transaction
+        if (!pwallet->IsReferred() && pwallet->mapWalletRTx.empty()) {
+            CScript script_dummy = CScript() << OP_TRUE;
+            pblocktemplate = BlockAssembler(Params()).CreateNewBlock(script_dummy);
+        } else {
+            std::shared_ptr<CReserveScript> coinbase_script;
+            pwallet->GetScriptForMining(coinbase_script);
+            pblocktemplate = BlockAssembler(Params()).CreateNewBlock(coinbase_script->reserveScript);
+            std::dynamic_pointer_cast<CReserveKey>(coinbase_script)->ReturnKey();
+        }
+#else
+        CScript script_dummy = CScript() << OP_TRUE;
+        pblocktemplate = BlockAssembler(Params()).CreateNewBlock(script_dummy);
+#endif
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
-
-        // Need to update only after we know CreateNewBlock succeeded
-        pindexPrev = pindexPrevNew;
     }
     CBlock* pblock = &pblocktemplate->block; // pointer for convenience
     const Consensus::Params& consensusParams = Params().GetConsensus();
@@ -583,7 +590,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     // Update nTime
     UpdateTime(pblock, consensusParams, pindexPrev);
     pblock->nNonce = 0;
-
     UniValue aCaps(UniValue::VARR); aCaps.push_back("proposal");
 
     UniValue transactions(UniValue::VARR);
@@ -621,6 +627,65 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         transactions.push_back(entry);
     }
 
+    i = 0;
+    UniValue invites(UniValue::VARR);
+    for (const auto& it : pblock->invites) {
+        const CTransaction& tx = *it;
+        uint256 txHash = tx.GetHash();
+        setTxIndex[txHash] = i++;
+
+        if (tx.IsCoinBase())
+            continue;
+
+        UniValue entry(UniValue::VOBJ);
+
+        entry.push_back(Pair("data", EncodeHexTx(tx)));
+        entry.push_back(Pair("txid", txHash.GetHex()));
+        entry.push_back(Pair("hash", tx.GetWitnessHash().GetHex()));
+
+        UniValue deps(UniValue::VARR);
+        for (const CTxIn &in : tx.vin)
+        {
+            if (setTxIndex.count(in.prevout.hash))
+                deps.push_back(setTxIndex[in.prevout.hash]);
+        }
+        entry.push_back(Pair("depends", deps));
+
+        int index_in_template = i - 1;
+        int64_t nTxSigOps = pblocktemplate->vTxSigOpsCost[index_in_template];
+
+        entry.push_back(Pair("sigops", nTxSigOps));
+        entry.push_back(Pair("weight", GetTransactionWeight(tx)));
+
+        invites.push_back(entry);
+    }
+
+    i = 0;
+    UniValue referrals(UniValue::VARR);
+    std::map<referral::Address, uint256> ref_parents;
+
+    for (const auto& it : pblock->m_vRef) {
+        const referral::Referral& referral = *it;
+        ref_parents[referral.GetAddress()] = referral.GetHash();
+
+        debug("%s::%s", HexStr(referral.GetAddress()), HexStr(referral.parentAddress));
+
+        UniValue entry(UniValue::VOBJ);
+
+        entry.push_back(Pair("data", EncodeHexRef(referral)));
+        entry.push_back(Pair("refid", referral.GetHash().GetHex()));
+        entry.push_back(Pair("hash", referral.GetHash().GetHex()));
+
+        UniValue deps(UniValue::VARR);
+        if (ref_parents.count(referral.parentAddress)) {
+            deps.push_back(ref_parents[referral.parentAddress].GetHex());
+        }
+        entry.push_back(Pair("depends", deps));
+        entry.push_back(Pair("weight", GetReferralWeight(referral)));
+
+        referrals.push_back(entry);
+    }
+
     UniValue aux(UniValue::VOBJ);
     aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
 
@@ -629,68 +694,17 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     UniValue aMutable(UniValue::VARR);
     aMutable.push_back("time");
     aMutable.push_back("transactions");
+    aMutable.push_back("invites");
+    aMutable.push_back("referrals");
     aMutable.push_back("prevblock");
 
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("capabilities", aCaps));
-
-    UniValue aRules(UniValue::VARR);
-    UniValue vbavailable(UniValue::VOBJ);
-    for (int j = 0; j < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j) {
-        Consensus::DeploymentPos pos = Consensus::DeploymentPos(j);
-        ThresholdState state = VersionBitsState(pindexPrev, consensusParams, pos, versionbitscache);
-        switch (state) {
-            case THRESHOLD_DEFINED:
-            case THRESHOLD_FAILED:
-                // Not exposed to GBT at all
-                break;
-            case THRESHOLD_LOCKED_IN:
-                // Ensure bit is set in block version
-                pblock->nVersion |= VersionBitsMask(consensusParams, pos);
-                // FALL THROUGH to get vbavailable set...
-            case THRESHOLD_STARTED:
-            {
-                const struct VBDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
-                vbavailable.push_back(Pair(gbt_vb_name(pos), consensusParams.vDeployments[pos].bit));
-                if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
-                    if (!vbinfo.gbt_force) {
-                        // If the client doesn't support this, don't indicate it in the [default] version
-                        pblock->nVersion &= ~VersionBitsMask(consensusParams, pos);
-                    }
-                }
-                break;
-            }
-            case THRESHOLD_ACTIVE:
-            {
-                // Add to rules only
-                const struct VBDeploymentInfo& vbinfo = VersionBitsDeploymentInfo[pos];
-                aRules.push_back(gbt_vb_name(pos));
-                if (setClientRules.find(vbinfo.name) == setClientRules.end()) {
-                    // Not supported by the client; make sure it's safe to proceed
-                    if (!vbinfo.gbt_force) {
-                        // If we do anything other than throw an exception here, be sure version/force isn't sent to old clients
-                        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Support for '%s' rule requires explicit client support", vbinfo.name));
-                    }
-                }
-                break;
-            }
-        }
-    }
     result.push_back(Pair("version", pblock->nVersion));
-    result.push_back(Pair("rules", aRules));
-    result.push_back(Pair("vbavailable", vbavailable));
-    result.push_back(Pair("vbrequired", int(0)));
-
-    if (nMaxVersionPreVB >= 2) {
-        // If VB is supported by the client, nMaxVersionPreVB is -1, so we won't get here
-        // Because BIP 34 changed how the generation transaction is serialized, we can only use version/force back to v2 blocks
-        // This is safe to do [otherwise-]unconditionally only because we are throwing an exception above if a non-force deployment gets activated
-        // Note that this can probably also be removed entirely after the first BIP9 non-force deployment (ie, probably segwit) gets activated
-        aMutable.push_back("version/force");
-    }
-
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));
+    result.push_back(Pair("invites", invites));
+    result.push_back(Pair("referrals", referrals));
     result.push_back(Pair("coinbaseaux", aux));
     result.push_back(Pair("coinbasevalue", static_cast<int64_t>(pblock->vtx[0]->vout[0].nValue)));
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -262,7 +262,7 @@ void CTxMemPool::CalculateReferralsConfirmations(
 
         auto tx = it->GetSharedEntryValue();
         if (tx->IsInvite()) {
-            debug("Found confirmation in mempool: %s,  %s",
+            debug("Found confirmation in mempool: %s, %s",
                     tx->GetHash().GetHex(),
                     CMeritAddress{
                         static_cast<char>(index.first.type),

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4361,8 +4361,7 @@ std::set<CTxDestination> CWallet::GetAccountAddresses(const std::string& strAcco
 
 bool CReserveKey::GetReservedKey(CPubKey& pubkey)
 {
-    if (nIndex == -1)
-    {
+    if (nIndex == -1) {
         CKeyPool keypool;
         pwallet->ReserveKeyFromKeyPool(nIndex, keypool);
         if (nIndex != -1)
@@ -4378,8 +4377,9 @@ bool CReserveKey::GetReservedKey(CPubKey& pubkey)
 
 void CReserveKey::KeepKey()
 {
-    if (nIndex != -1)
+    if (nIndex != -1) {
         pwallet->KeepKey(nIndex);
+    }
     nIndex = -1;
     vchPubKey = CPubKey();
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -194,19 +194,14 @@ referral::ReferralRef CWallet::Unlock(const referral::Address& parentAddress, co
 
     // check parent address and alias not to generate keys
     // TODO: remove generated key from map if referral transaction failed and remove this checks
-    const bool isBeaconed = CheckAddressBeaconed(parentAddress, true);
-
-    if (!isBeaconed) {
+    if (!CheckAddressBeaconed(parentAddress, true)) {
         throw std::runtime_error(std::string(__func__) + ": provided address is not beaconed");
     }
 
-    bool isConfirmed = true;
-    if(Daedalus()) {
-        isConfirmed = CheckAddressConfirmed(parentAddress, true);
-    }
-
-    if (!isConfirmed) {
-        throw std::runtime_error(std::string(__func__) + ": provided address is not confirmed");
+    if (Daedalus()) {
+        if (!CheckAddressConfirmed(parentAddress, true)) {
+            throw std::runtime_error(std::string(__func__) + ": provided address is not confirmed");
+        }
     }
 
     // check if provided referral's alias is valid and not yet occupied


### PR DESCRIPTION
 - miner now looks for confirmations both in the current assembled block state and current tx package
- miner build ordered referrals tree and validates it, like it is done for block validation
- `getblocktemplate` is updated with invites, referrals and latest daedalus changes