### PR TITLE
Some quick optimizations.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1165,7 +1165,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     } else {
                         // Send block from disk
                         std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
-                        if (!ReadBlockFromDisk(*pblockRead, (*mi).second, consensusParams))
+                        if (!ReadBlockFromDisk(*pblockRead, (*mi).second, consensusParams, false))
                             assert(!"cannot load block from disk");
                         pblock = pblockRead;
                     }
@@ -1872,7 +1872,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
 
         CBlock block;
-        bool ret = ReadBlockFromDisk(block, it->second, chainparams.GetConsensus());
+        bool ret = ReadBlockFromDisk(block, it->second, chainparams.GetConsensus(), false);
         assert(ret);
 
         SendBlockTransactions(block, req, pfrom, connman);
@@ -3321,7 +3321,7 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
                     }
                     if (!fGotBlockFromCache) {
                         CBlock block;
-                        bool ret = ReadBlockFromDisk(block, pBestIndex, consensusParams);
+                        bool ret = ReadBlockFromDisk(block, pBestIndex, consensusParams, false);
                         assert(ret);
                         BlockHeaderAndShortIDs cmpctblock(block, state.fWantsCmpctWitness);
                         connman.PushMessage(pto, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, cmpctblock));

--- a/src/pog/anv.cpp
+++ b/src/pog/anv.cpp
@@ -23,9 +23,13 @@ namespace pog
         return db.GetAllANVs();
     }
 
-    referral::AddressANVs GetAllRewardableANVs(const referral::ReferralsViewDB& db)
+    void GetAllRewardableANVs(
+            const referral::ReferralsViewDB& db,
+            const Consensus::Params& params,
+            int height,
+            referral::AddressANVs& entrants)
     {
-        return db.GetAllRewardableANVs();
+        db.GetAllRewardableANVs(params, height, entrants);
     }
 
     referral::AddressANVs GetANVs(

--- a/src/pog/anv.h
+++ b/src/pog/anv.h
@@ -6,6 +6,7 @@
 #define MERIT_POG_ANV_H
 
 #include "primitives/referral.h"
+#include "consensus/params.h"
 #include "refdb.h"
 
 #include <vector>
@@ -16,10 +17,21 @@ namespace pog
      * Aggregate Network Value is computed by walking the referral tree down from the 
      * key_id specified and aggregating each child's ANV.
      */
-    referral::MaybeAddressANV ComputeANV(const referral::Address&, const referral::ReferralsViewDB&);
-    referral::AddressANVs GetANVs(const referral::Addresses& addresses, const referral::ReferralsViewDB&);
+    referral::MaybeAddressANV ComputeANV(
+            const referral::Address&,
+            const referral::ReferralsViewDB&);
+
+    referral::AddressANVs GetANVs(
+            const referral::Addresses& addresses,
+            const referral::ReferralsViewDB&);
+
     referral::AddressANVs GetAllANVs(const referral::ReferralsViewDB&);
-    referral::AddressANVs GetAllRewardableANVs(const referral::ReferralsViewDB&);
+
+    void GetAllRewardableANVs(
+            const referral::ReferralsViewDB&,
+            const Consensus::Params&,
+            int height,
+            referral::AddressANVs&);
 
 } // namespace pog
 

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -10,6 +10,7 @@
 #include "serialize.h"
 #include "primitives/referral.h"
 #include "primitives/transaction.h"
+#include "consensus/params.h"
 #include "pog/wrs.h"
 
 #include <boost/optional.hpp>
@@ -99,7 +100,10 @@ public:
     bool InsertReferral(const Referral&, bool allow_no_parent = false);
     bool RemoveReferral(const Referral&);
 
-    AddressANVs GetAllRewardableANVs() const;
+    void GetAllRewardableANVs(
+            const Consensus::Params& params,
+            int height,
+            AddressANVs&) const;
 
     bool AddAddressToLottery(
             int height,

--- a/src/validation.h
+++ b/src/validation.h
@@ -531,8 +531,17 @@ void InitScriptExecutionCache();
 
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
-bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
+bool ReadBlockFromDisk(
+        CBlock& block,
+        const CDiskBlockPos& pos,
+        const Consensus::Params& consensusParams,
+        bool validate = true);
+
+bool ReadBlockFromDisk(
+        CBlock& block,
+        const CBlockIndex* pindex,
+        const Consensus::Params& consensusParams,
+        bool validate = true);
 
 /** Functions for validating blocks and updating the block tree */
 


### PR DESCRIPTION
1. Don't check PoW on block read when it isn't necessary. - Overall speedup including Daedalus.
     a) PoW on reindex was checked twice for example.
2. Faster genesis block filter in computing ambassador lottery entrants.
3. Don't verify PoW on block read when sending block (potential for DDOS)

Overall speedup before Daedalus is 2x for reindex