### PR TITLE
Enhance mining interface

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -1055,6 +1055,7 @@ void static MeritMiner(const CChainParams& chainparams, uint8_t nThreads)
         throw;
     } catch (const std::runtime_error& e) {
         LogPrintf("MeritMiner runtime error: %s\n", e.what());
+        gArgs.ForceSetArg("-mine", 0);
         return;
     }
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -559,7 +559,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     static std::unique_ptr<CBlockTemplate> pblocktemplate;
     if (pindexPrev != chainActive.Tip() || (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
     {
-        // Clear pindexPrev so future calls make a new block, despite any failures from here on  
+        // Clear pindexPrev so future calls make a new block, despite any failures from here on
         pindexPrev = nullptr;
 
         // Store the pindexBest used before CreateNewBlock, to avoid races
@@ -1030,7 +1030,7 @@ UniValue setmining(const JSONRPCRequest& request)
 
     GenerateMerit(mine, nThreads, Params());
 
-    return NullUniValue;
+    return gArgs.GetBoolArg("-mine", DEFAULT_MINING);
 }
 
 UniValue getmining(const JSONRPCRequest& request)


### PR DESCRIPTION
Change status of mining on errors and return response from RPC call
- [x] if miner crashes, mining flag is reset to false
- [x] response added to `setmining` RPC request 