### PR TITLE
OSX code signing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,7 @@ $(OSX_APP)/Contents/PkgInfo:
 
 $(OSX_APP)/Contents/Resources/empty.lproj:
 	$(MKDIR_P) $(@D)
-	@touch $@ 
+	@touch $@
 
 $(OSX_APP)/Contents/Info.plist: $(OSX_PLIST)
 	$(MKDIR_P) $(@D)
@@ -109,7 +109,7 @@ osx_volname:
 
 if BUILD_DARWIN
 $(OSX_DMG): $(OSX_APP_BUILT) $(OSX_PACKAGING) $(OSX_BACKGROUND_IMAGE)
-	$(PYTHON) $(OSX_DEPLOY_SCRIPT) $(OSX_APP) -add-qt-tr $(OSX_QT_TRANSLATIONS) -translations-dir=$(QT_TRANSLATION_DIR) -dmg -fancy $(OSX_FANCY_PLIST) -verbose 2 -volname $(OSX_VOLNAME)
+	$(PYTHON) $(OSX_DEPLOY_SCRIPT) $(OSX_APP) -add-qt-tr $(OSX_QT_TRANSLATIONS) -translations-dir=$(QT_TRANSLATION_DIR) -dmg $(if $(CODESIGNARGS), -sign, ) -fancy $(OSX_FANCY_PLIST) -verbose 2 -volname $(OSX_VOLNAME)
 
 $(OSX_BACKGROUND_IMAGE).png: contrib/macdeploy/$(OSX_BACKGROUND_SVG)
 	sed 's/PACKAGE_NAME/$(PACKAGE_NAME)/' < "$<" | $(RSVG_CONVERT) -f png -d 36 -p 36 -o $@

--- a/contrib/code-signing/sign-osx.sh
+++ b/contrib/code-signing/sign-osx.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Copyright (c) 2018 The Merit Foundation developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+set -euo pipefail
+
+ROOTDIR=dist
+BUNDLE="${ROOTDIR}/Merit-Qt.app"
+PACKAGE="Merit-Qt.dmg"
+CODESIGN=codesign
+
+IDENTITY="$1"
+
+echo "Signing installer image with identity ${IDENTITY}\n"
+${CODESIGN} -s ${IDENTITY} ${PACKAGE}

--- a/contrib/code-signing/sign-osx.sh
+++ b/contrib/code-signing/sign-osx.sh
@@ -10,7 +10,37 @@ BUNDLE="${ROOTDIR}/Merit-Qt.app"
 PACKAGE="Merit-Qt.dmg"
 CODESIGN=codesign
 
-IDENTITY="$1"
+IDENTITY=${1:-}
+APP_TYPE=${2:-}
 
-echo "Signing installer image with identity ${IDENTITY}\n"
-${CODESIGN} -s ${IDENTITY} ${PACKAGE}
+function help {
+    echo "usage: $0 <identitty> <app-type>"
+    echo "    app-type: 1 or 2"
+    echo "    1 - sign ${BUNDLE}"
+    echo "    2 - sign ${PACKAGE}"
+    echo "example: $0 MyIdentity 1"
+
+    exit 1
+}
+
+if [[ -z "$IDENTITY" ]]; then
+    help
+fi
+
+if [[ -z "$APP_TYPE" ]]; then
+    help
+fi
+
+if [ "$APP_TYPE" == "1" ]; then
+    echo "Signing application code with identity ${IDENTITY}\n"
+    ${CODESIGN} -s ${IDENTITY} -v --deep ${BUNDLE}
+    echo "Verifying signatured"
+    ${CODESIGN} -v ${BUNDLE}
+fi
+
+if [ "$APP_TYPE" == "2" ]; then
+    echo "Signing installer image with identity ${IDENTITY}\n"
+    ${CODESIGN} -s ${IDENTITY} -v --deep ${PACKAGE}
+    echo "Verifying signatured"
+    ${CODESIGN} -v ${PACKAGE}
+fi

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -26,11 +26,11 @@
   <string>@CLIENT_VERSION_MAJOR@.@CLIENT_VERSION_MINOR@.@CLIENT_VERSION_REVISION@</string>
 
   <key>CFBundleSignature</key>
-  <string>????</string>
+  <string>org.meritfoundation.Merit-Qt</string>
 
   <key>CFBundleExecutable</key>
   <string>Merit-Qt</string>
-  
+
   <key>CFBundleName</key>
   <string>Merit-Qt</string>
 
@@ -99,7 +99,7 @@
 
   <key>LSAppNapIsDisabled</key>
     <string>True</string>
-  
+
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>
 </dict>


### PR DESCRIPTION
This PR enables automatic code signing on `deploy` task call if variables provided

To sign .app and .dmg automatically:
```
export CODESIGNARGS='--sign "Developer ID Application: ..." --keychain /encrypted/foo.keychain'
make deploy
```

It also adds a script to sign .app or .dmg manually:
```
contrib/code-signing/sign-osx.sh <identitty> <app-type>
```
app-type is 1 for .app and 2 for .dmg