### PR TITLE
Allow network and transaction listviews to scroll

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -584,10 +584,13 @@ background-color: rgb(232, 179, 54);</string>
              <enum>QFrame::NoFrame</enum>
             </property>
             <property name="verticalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
+             <enum>Qt::ScrollBarAsNeeded</enum>
             </property>
             <property name="horizontalScrollBarPolicy">
              <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QAbstractScrollArea::AdjustToContents</enum>
             </property>
             <property name="selectionMode">
              <enum>QAbstractItemView::NoSelection</enum>
@@ -686,10 +689,13 @@ background-color: rgb(232, 179, 54);</string>
              <enum>QFrame::NoFrame</enum>
             </property>
             <property name="verticalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
+             <enum>Qt::ScrollBarAsNeeded</enum>
             </property>
             <property name="horizontalScrollBarPolicy">
              <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QAbstractScrollArea::AdjustToContents</enum>
             </property>
             <property name="selectionMode">
              <enum>QAbstractItemView::NoSelection</enum>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -245,13 +245,13 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
 
     // Recent transactions
     ui->listTransactions->setItemDelegate(txdelegate);
-    ui->listTransactions->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
+    ui->listTransactions->setMinimumHeight(DECORATION_SIZE + 2);
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->inviteNotice->hide();
 
     // Unlock Requests
     ui->listNetwork->setItemDelegate(referraldelegate);
-    ui->listNetwork->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
+    ui->listNetwork->setMinimumHeight(DECORATION_SIZE + 2);
     ui->listNetwork->setAttribute(Qt::WA_MacShowFocusRect, false);
 
     connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));


### PR DESCRIPTION
this allows the qt-wallet to be resized to a much smaller size than before