### PR TITLE
Fix use of invalidated iterator which can cause a crash.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1984,6 +1984,8 @@ void CConnman::ThreadMessageHandler()
 
         for (CNode* pnode : vNodesCopy)
         {
+            assert(pnode);
+
             if (pnode->fDisconnect)
                 continue;
 

--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -55,7 +55,7 @@ MutableReferral::MutableReferral(
     pubkey{pubkeyIn},
     signature{valtype()}
     {
-        assert(aliasIn.size() < MAX_ALIAS_LENGTH);
+        assert(aliasIn.size() <= MAX_ALIAS_LENGTH);
         if (addressType == 1) {
             address = addressIn;
         } else {


### PR DESCRIPTION
A crash can happen when using an invalidated iterator when an orphan referral
is removed from the mempool. This commit fixes that issue by erasing
the iterator at the end after using it.

Another potential source of crashes is the EraseOrphanfor function which
iterated over the transaction and referral maps while erasing from the maps.
The code was changed to step over the potentially erased iterator.