### PR TITLE
Error on alias duplicat in mempool when looking up the address.

### DIFF
--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -238,8 +238,6 @@ inline void SerializeReferral(const RefType& ref, Stream& s)
     }
 }
 
-typedef std::shared_ptr<const Referral> ReferralRef;
-
 template <typename Ref>
 static inline ReferralRef MakeReferralRef(Ref&& referralIn)
 {

--- a/src/refmempool.h
+++ b/src/refmempool.h
@@ -222,10 +222,10 @@ public:
     ReferralRef Get(const Address& address) const;
 
     /** Get referral by alias */
-    ReferralRef Get(const std::string& alias) const;
+    ReferralRefs Get(const std::string& alias) const;
 
     /** Get referral by id - hash, address or alias */
-    ReferralRef Get(const ReferralId& referral_id) const;
+    ReferralRefs Get(const ReferralId& referral_id) const;
 
     /** Find all referrals with given alias */
     std::pair<RefAliasIter, RefAliasIter> Find(const std::string& alias) const;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -94,6 +94,7 @@ public:
  *  A CTxDestination is the internal data type encoded in a merit address
  */
 using CTxDestination = boost::variant<CNoDestination, CKeyID, CScriptID, CParamScriptID>;
+using CTxDestinations = std::vector<CTxDestination>;
 
 /** returns a numberical type based on destination */
 char AddressTypeFromDestination(const CTxDestination&);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -55,6 +55,7 @@
 #include <atomic>
 #include <sstream>
 #include <numeric>
+#include <stdexcept>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -5180,7 +5181,7 @@ bool CheckAddressConfirmed(const CMeritAddress& addr, bool checkMempool)
     return maybe_hash ? CheckAddressConfirmed(*maybe_hash, addr.GetType(), checkMempool) : false;
 }
 
-CTxDestination LookupDestination(const std::string& address)
+CTxDestinations LookupDestinations(const std::string& address)
 {
     assert(prefviewdb);
 
@@ -5189,38 +5190,77 @@ CTxDestination LookupDestination(const std::string& address)
     // check if address is a valid destionation => it's an address
     // otherwise try to get referral by alias and get it's address
     if (IsValidDestination(dest)) {
-        return dest;
+        return {dest};
     }
 
     // Get referral by alias from cache
     auto cached_referral = prefviewdb->GetReferral(address);
     if (cached_referral) {
-        return CMeritAddress{cached_referral->addressType, cached_referral->GetAddress()}.Get();
+        return {CMeritAddress{cached_referral->addressType, cached_referral->GetAddress()}.Get()};
     }
 
     // Get referral by alias from cache
-    auto mempool_referral = mempoolReferral.Get(address);
-    if (mempool_referral) {
-        return CMeritAddress{mempool_referral->addressType, mempool_referral->GetAddress()}.Get();
+    auto mempool_referrals = mempoolReferral.Get(address);
+    if (!mempool_referrals.empty()) {
+        CTxDestinations dests;
+        for(const auto& ref: mempool_referrals) {
+            dests.push_back(CMeritAddress{ref->addressType, ref->GetAddress()}.Get());
+        }
+        return dests;
     }
 
     // if dest is not a valid festination and
     // we have no referrals assosiated with this alias
     // return decoded dest
-    return dest;
+    return {dest};
+}
+
+CTxDestination LookupDestination(const std::string& address)
+{
+    assert(prefviewdb);
+
+    auto dests = LookupDestinations(address);
+    if(dests.size() > 1) {
+        std::stringstream s;
+        s << "There are multiple destinations found with the alias " << address << std::endl;
+        s << "The conflicting destinations are..." << std::endl; 
+        for(const auto d : dests) {
+            s << '\t' << CMeritAddress{d}.ToString() << std::endl;
+        }
+        throw std::runtime_error{s.str()};
+    }
+
+    return dests.empty() ? CTxDestination{} : dests.front();
+}
+
+const referral::ReferralRefs LookupReferrals(referral::ReferralId& referral_id)
+{
+    auto cached_referral = prefviewdb->GetReferral(referral_id);
+
+    if(cached_referral) {
+        return {MakeReferralRef(*cached_referral)};
+    }
+
+    return mempoolReferral.Get(referral_id);
 }
 
 const referral::ReferralRef LookupReferral(referral::ReferralId& referral_id)
 {
-    auto mempool_referral = mempoolReferral.Get(referral_id);
-
-    if (mempool_referral) {
-        return mempool_referral;
+    auto mempool_referrals = LookupReferrals(referral_id);
+    if(mempool_referrals.size() > 1) {
+        std::stringstream s;
+        s << "There are multiple referrals found with the id specified" << std::endl;
+        s << "The conflicting referrals are..." << std::endl; 
+        for(const auto ref : mempool_referrals) {
+            s << "\tid:"
+              << ref->GetHash().GetHex()
+              << " address: "
+              << CMeritAddress{ref->addressType, ref->GetAddress()}.ToString()
+              << std::endl;
+        }
+        throw std::runtime_error{s.str()};
     }
-
-    auto cached_referral = prefviewdb->GetReferral(referral_id);
-
-    return cached_referral ? MakeReferralRef(*cached_referral) : nullptr;
+    return mempool_referrals.empty() ? nullptr : mempool_referrals.front();
 }
 
 bool IsWitnessCommitment(const CTxOut& out)

--- a/src/validation.h
+++ b/src/validation.h
@@ -577,11 +577,23 @@ bool CheckAddressConfirmed(const uint160&, char addr_type, bool checkMempool = t
 /** Check that an address is valid and ready to use */
 bool CheckAddressConfirmed(const CMeritAddress& addr, bool checkMempool = true);
 
+
+/**
+ * Try to decide if the address is an alias or an address.
+ * If it is an alias, lookup the address.
+ *
+ * It is possible to return multiple destinations if the alias is found in the
+ * mempool and there are conflicts
+ */
+CTxDestinations LookupDestinations(const std::string& address);
+
 /**
  * Try to decide if the address is an alias or an address.
  * If it is an alias, lookup the address.
  */
 CTxDestination LookupDestination(const std::string& address);
+
+const referral::ReferralRefs LookupReferrals(referral::ReferralId& referral_id);
 
 const referral::ReferralRef LookupReferral(referral::ReferralId& referral_id);
 


### PR DESCRIPTION
Also provides functions that can be used to improve the UI error handling.

Currently the merit-cli will get an error but it isn't ideal for the Qt interface.