### PR TITLE
Qt - show more invite requests

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -274,7 +274,6 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
     // Unlock Requests
     ui->listPendingRequests->setItemDelegate(referraldelegate);
     ui->listPendingRequests->setMinimumHeight(DECORATION_SIZE + 2);
-    ui->listPendingRequests->setMaximumHeight(3 * (DECORATION_SIZE + 2));
     ui->listPendingRequests->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->listApprovedRequests->setItemDelegate(referraldelegate);
     ui->listApprovedRequests->setMinimumHeight(DECORATION_SIZE + 2);
@@ -491,6 +490,10 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         ui->listPendingRequests->setModel(pendingRequestsFilter.get());
         ui->listApprovedRequests->setModel(approvedRequestsFilter.get());
+
+        // show up to 5 pending invite requests before having to scroll to view more.
+        ui->listPendingRequests->setMinimumHeight(
+            std::min(5, pendingRequestsFilter->rowCount()) * (DECORATION_SIZE + 2));
 
         is_confirmed = walletModel->IsConfirmed();
         UpdateInvitationStatus();


### PR DESCRIPTION
This branch changes the overview page expand the "Invitation Requests" section of the overview page when there are more than one pending request. It will expand to show all requests without scrolling until there are 6 or more requests. 

---

<img width="471" alt="screen shot 2018-02-19 at 11 02 26 am" src="https://user-images.githubusercontent.com/8847056/36393698-7dac3816-1565-11e8-81dc-f78dd7a46071.png">

---

Then, it will show 5 requests with a scrollbar to show the rest.

---

<img width="443" alt="screen shot 2018-02-19 at 11 04 44 am" src="https://user-images.githubusercontent.com/8847056/36393702-82af55dc-1565-11e8-9330-8d714aa02747.png">
