### PR TITLE
Do not generate new hd key on wallet encryption

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -898,7 +898,7 @@ UniValue inviteaddress(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() == 0 || request.params.size() > 2)
         throw std::runtime_error(
-            "inviteaddress \"address\" (amount)" 
+            "inviteaddress \"address\" (amount)"
             "\nConfirm given address's referral.\n"
             + HelpRequiringPassphrase(pwallet) +
             "\nArguments:\n"
@@ -3963,7 +3963,7 @@ UniValue encryptwallet(const JSONRPCRequest& request)
     // slack space in .dat files; that is bad if the old data is
     // unencrypted private keys. So:
     StartShutdown();
-    return "wallet encrypted; Merit server stopping, restart to run with encrypted wallet. The keypool has been flushed and a new HD seed was generated (if you are using HD). You need to make a new backup.";
+    return "wallet encrypted; Merit server stopping, restart to run with encrypted wallet.";
 }
 
 UniValue lockunspent(const JSONRPCRequest& request)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3963,7 +3963,7 @@ UniValue encryptwallet(const JSONRPCRequest& request)
     // slack space in .dat files; that is bad if the old data is
     // unencrypted private keys. So:
     StartShutdown();
-    return "wallet encrypted; Merit server stopping, restart to run with encrypted wallet.";
+    return "wallet encrypted; Merit server stopping, restart to run with encrypted wallet. You need to make a new backup.";
 }
 
 UniValue lockunspent(const JSONRPCRequest& request)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -768,17 +768,6 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         pwalletdbEncryption = nullptr;
 
         Lock();
-        Unlock(strWalletPassphrase);
-
-        // if we are using HD, replace the HD master key (seed) with a new one
-        if (IsHDEnabled()) {
-            if (!SetHDMasterKey(GenerateNewHDMasterKey())) {
-                return false;
-            }
-        }
-
-        NewKeyPool();
-        Lock();
 
         // Need to completely rewrite the wallet file; if we don't, bdb might keep
         // bits of the unencrypted private key in slack space in the database file.


### PR DESCRIPTION
Fix for #257 
Get rid of generation new HD key on wallet encryption, not to spend an invite for new key and pool