### PR TITLE
The assert detected a bad db state.

### DIFF
--- a/src/refdb.cpp
+++ b/src/refdb.cpp
@@ -824,7 +824,9 @@ namespace referral
             new_confirmation = true;
         } else {
             confirmation.second += amount;
-            assert(confirmation.second >= 0);
+            if(confirmation.second < 0) {
+                return false;
+            }
         }
 
         if (!m_db.Write(


### PR DESCRIPTION
Another bug caused the indices to be in an inconsistent state which triggered this assert. 
We shouldn't assert on bad input only logic.