### PR TITLE
Bug/cache invalidation with disconnect block

### DIFF
--- a/src/referrals.cpp
+++ b/src/referrals.cpp
@@ -90,10 +90,10 @@ void ReferralsViewCache::InsertReferralIntoCache(const Referral& ref) const
     referrals_index.insert(ref);
 }
 
-void ReferralsViewCache::RemoveReferral(const Referral& ref) const
+bool ReferralsViewCache::RemoveReferral(const Referral& ref) const
 {
     referrals_index.erase(ref.GetAddress());
-    m_db->RemoveReferral(ref);
+    return m_db->RemoveReferral(ref);
 }
 
 bool ReferralsViewCache::IsConfirmed(const Address& address) const

--- a/src/referrals.h
+++ b/src/referrals.h
@@ -89,7 +89,7 @@ public:
     bool Exists(const std::string&) const;
 
     /** Remove referral from cache */
-    void RemoveReferral(const Referral&) const;
+    bool RemoveReferral(const Referral&) const;
 
     /** Flush referrals to disk and clear cache */
     void Flush();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2673,7 +2673,7 @@ bool RemoveReferrals(const CBlock& block)
 
     // Update offset and Record referrals into the referral DB
     for (const auto& rtx : block.m_vRef) {
-        if (!prefviewdb->RemoveReferral(*rtx))
+        if (!prefviewcache->RemoveReferral(*rtx))
             return false;
     }
     return true;


### PR DESCRIPTION
CheckAddressBeacon uses the in memory cache to figure out
if an address has already been beaconed. This cache wasn't properly
updated when DisconnectBlock was called. This means if a referral
was beaconed on an orphaned branch of the blockchain, All nodes will reject all
future blocks with that beacon causing mini forks and bans throughout the network.