### PR TITLE
Undo Data was missing invite metadata information.

### DIFF
--- a/src/undo.h
+++ b/src/undo.h
@@ -13,55 +13,6 @@
 #include "serialize.h"
 #include "refdb.h"
 
-/** Undo information for a CTxIn
- *
- *  Contains the prevout's CTxOut being spent, and its metadata as well
- *  (coinbase or not, height). The serialization contains a dummy value of
- *  zero. This is be compatible with older versions which expect to see
- *  the transaction version there.
- */
-class TxInUndoSerializer
-{
-    const Coin* txout;
-
-public:
-    template<typename Stream>
-    void Serialize(Stream &s) const {
-        ::Serialize(s, VARINT(txout->nHeight * 2 + (txout->fCoinBase ? 1 : 0)));
-        if (txout->nHeight > 0) {
-            // Required to maintain compatibility with older undo format.
-            ::Serialize(s, (unsigned char)0);
-        }
-        ::Serialize(s, CTxOutCompressor(REF(txout->out)));
-    }
-
-    explicit TxInUndoSerializer(const Coin* coin) : txout(coin) {}
-};
-
-class TxInUndoDeserializer
-{
-    Coin* txout;
-
-public:
-    template<typename Stream>
-    void Unserialize(Stream &s) {
-        unsigned int nCode = 0;
-        ::Unserialize(s, VARINT(nCode));
-        txout->nHeight = nCode / 2;
-        txout->fCoinBase = nCode & 1;
-        if (txout->nHeight > 0) {
-            // Old versions stored the version number for the last spend of
-            // a transaction's outputs. Non-final spends were indicated with
-            // height = 0.
-            int nVersionDummy;
-            ::Unserialize(s, VARINT(nVersionDummy));
-        }
-        ::Unserialize(s, REF(CTxOutCompressor(REF(txout->out))));
-    }
-
-    explicit TxInUndoDeserializer(Coin* coin) : txout(coin) {}
-};
-
 static const size_t MIN_TRANSACTION_INPUT_WEIGHT = WITNESS_SCALE_FACTOR * ::GetSerializeSize(CTxIn(), SER_NETWORK, PROTOCOL_VERSION);
 static const size_t MAX_INPUTS_PER_BLOCK = MAX_BLOCK_WEIGHT / MIN_TRANSACTION_INPUT_WEIGHT;
 
@@ -74,26 +25,12 @@ public:
 
     template <typename Stream>
     void Serialize(Stream& s) const {
-        // TODO: avoid reimplementing vector serializer
-        uint64_t count = vprevout.size();
-        ::Serialize(s, COMPACTSIZE(REF(count)));
-        for (const auto& prevout : vprevout) {
-            ::Serialize(s, REF(TxInUndoSerializer(&prevout)));
-        }
+        ::Serialize(s, vprevout);
     }
 
     template <typename Stream>
     void Unserialize(Stream& s) {
-        // TODO: avoid reimplementing vector deserializer
-        uint64_t count = 0;
-        ::Unserialize(s, COMPACTSIZE(count));
-        if (count > MAX_INPUTS_PER_BLOCK) {
-            throw std::ios_base::failure("Too many input undo records");
-        }
-        vprevout.resize(count);
-        for (auto& prevout : vprevout) {
-            ::Unserialize(s, REF(TxInUndoDeserializer(&prevout)));
-        }
+        ::Unserialize(s, REF(vprevout));
     }
 };
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2563,18 +2563,6 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
 
     if (view.HaveCoin(out)) fClean = false; // overwriting transaction output
 
-    if (undo.nHeight == 0) {
-        // Missing undo metadata (height and coinbase). Older versions included this
-        // information only in undo records for the last spend of a transactions'
-        // outputs. This implies that it must be present for some other output of the same tx.
-        const Coin& alternate = AccessByTxid(view, out.hash);
-        if (!alternate.IsSpent()) {
-            undo.nHeight = alternate.nHeight;
-            undo.fCoinBase = alternate.fCoinBase;
-        } else {
-            return DISCONNECT_FAILED; // adding output for transaction without known metadata
-        }
-    }
     // The potential_overwrite parameter to AddCoin is only allowed to be false if we know for
     // sure that the coin did not already exist in the cache. As we have queried for that above
     // using HaveCoin, we don't need to guess. When fClean is false, a coin already existed and


### PR DESCRIPTION
This caused nodes to throw a

    bad-invite-input-is-not-invite

For valid blocks that included a transaction with
invites that was included in a forked but abandoned
chain.