### PR TITLE
The miner can package the transactions in the wrong order.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -573,7 +573,7 @@ void BlockAssembler::SortForBlock(
     // transactions for block inclusion.
     sortedEntries.clear();
     sortedEntries.insert(sortedEntries.begin(), package.begin(), package.end());
-    std::sort(sortedEntries.begin(), sortedEntries.end(), CompareIteratorByEntryTime<CTxMemPool::txiter>());
+    std::sort(sortedEntries.begin(), sortedEntries.end(), CompareTxIterByAncestorCount());
 }
 
 void BlockAssembler::AddReferrals()


### PR DESCRIPTION
A bug was introduced where we sorted on time instead of ancestor count. This made it possible for transactions to sorted in the
wrong order.