### PR TITLE
Invite lottery was broken when disconnecting blocks.

### DIFF
--- a/src/pog/reward.cpp
+++ b/src/pog/reward.cpp
@@ -67,7 +67,7 @@ namespace pog
             const InviteLotteryParams& lottery,
             const Consensus::Params& params)
     {
-        debug("Invites used: %d created: %d period: %d used per block: %d", 
+        LogPrint(BCLog::VALIDATION, "Invites used: %d created: %d period: %d used per block: %d",
                 lottery.invites_used,
                 lottery.invites_created,
                 params.daedalus_block_window,


### PR DESCRIPTION
We did not properly resize the lottery pool when disconnecting blocks,
changing the outcome of the invite lottery. Now the invite pool is shrunken
only when the last entry has zero invites. This is safe because the pool
is stored in time order.