### PR TITLE
Better and Safer Aliases

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -159,7 +159,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].end_block = 312020;   // About Aug 2, 2018
 
         // Block where safer aliases are enabled.
-        consensus.safer_alias_blockheight = 92000;
+        consensus.safer_alias_blockheight = 94200;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000002");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -158,6 +158,9 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].start_block = 49000; // About Feb 2, 2018
         consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].end_block = 312020;   // About Aug 2, 2018
 
+        // Block where safer aliases are enabled.
+        consensus.safer_alias_blockheight = 90000;
+
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000002");
 
@@ -291,6 +294,9 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("14933df1e491d761a3972449bc88f3525f2081060af8534f8e54ad8d793f61b0"); //1135275
 
+        // Block where safer aliases are enabled.
+        consensus.safer_alias_blockheight = 3000;
+
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -413,6 +419,9 @@ public:
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00");
+
+        // Block where safer aliases are enabled.
+        consensus.safer_alias_blockheight = 3000;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -159,7 +159,7 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].end_block = 312020;   // About Aug 2, 2018
 
         // Block where safer aliases are enabled.
-        consensus.safer_alias_blockheight = 90000;
+        consensus.safer_alias_blockheight = 92000;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000000000000000000000000002");
@@ -295,7 +295,7 @@ public:
         consensus.defaultAssumeValid = uint256S("14933df1e491d761a3972449bc88f3525f2081060af8534f8e54ad8d793f61b0"); //1135275
 
         // Block where safer aliases are enabled.
-        consensus.safer_alias_blockheight = 3000;
+        consensus.safer_alias_blockheight = 2060;
 
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
@@ -421,7 +421,7 @@ public:
         consensus.defaultAssumeValid = uint256S("0x00");
 
         // Block where safer aliases are enabled.
-        consensus.safer_alias_blockheight = 3000;
+        consensus.safer_alias_blockheight = 2060;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -87,6 +87,9 @@ struct Params {
     int daedalus_block_window;
     int daedalus_min_one_invite_for_every_x_blocks;
     int daedalus_max_outstanding_invites_per_address;
+    
+    /** Bug Fix heights */
+    int safer_alias_blockheight;
 
 };
 } // namespace Consensus

--- a/src/consensus/ref_verify.cpp
+++ b/src/consensus/ref_verify.cpp
@@ -10,27 +10,33 @@
 
 namespace referral
 {
-bool CheckReferral(const Referral& referral, CValidationState& state)
-{
-    // Basic checks that don't depend on any context
-    if (referral.GetAddress().IsNull()) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-ref-no-address");
-    }
-
-    // Check referral pubkey and signature
-    if (!referral.pubkey.IsValid()) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-ref-invalid-pubkey");
-    } else {
-        if (referral.signature.empty()) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-ref-sig-empty");
+    bool CheckReferral(
+            const Referral& referral,
+            int blockheight,
+            const Consensus::Params& params,
+            CValidationState& state)
+    {
+        // Basic checks that don't depend on any context
+        if (referral.GetAddress().IsNull()) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-ref-no-address");
         }
-    }
 
-    if (referral.version >= Referral::INVITE_VERSION && !CheckReferralAlias(referral.alias)) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-ref-invalid-alias");
-    }
+        // Check referral pubkey and signature
+        if (!referral.pubkey.IsValid()) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-ref-invalid-pubkey");
+        } else {
+            if (referral.signature.empty()) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-ref-sig-empty");
+            }
+        }
 
-    return true;
-}
+        if (referral.version >= Referral::INVITE_VERSION 
+                && !CheckReferralAlias(referral.alias, blockheight, params)) {
+
+            return state.DoS(100, false, REJECT_INVALID, "bad-ref-invalid-alias");
+        }
+
+        return true;
+    }
 
 } //namespace referral

--- a/src/consensus/ref_verify.cpp
+++ b/src/consensus/ref_verify.cpp
@@ -12,8 +12,7 @@ namespace referral
 {
     bool CheckReferral(
             const Referral& referral,
-            int blockheight,
-            const Consensus::Params& params,
+            bool normalize_alias,
             CValidationState& state)
     {
         // Basic checks that don't depend on any context
@@ -31,7 +30,7 @@ namespace referral
         }
 
         if (referral.version >= Referral::INVITE_VERSION 
-                && !CheckReferralAlias(referral.alias, blockheight, params)) {
+                && !CheckReferralAlias(referral.alias, normalize_alias)) {
 
             return state.DoS(100, false, REJECT_INVALID, "bad-ref-invalid-alias");
         }

--- a/src/consensus/ref_verify.h
+++ b/src/consensus/ref_verify.h
@@ -22,8 +22,7 @@ namespace referral
     /** Context-independent validity checks */
     bool CheckReferral(
             const Referral& referral,
-            int blockheight,
-            const Consensus::Params& params,
+            bool normalize_alias,
             CValidationState& state);
 
 } //namespace referral

--- a/src/consensus/ref_verify.h
+++ b/src/consensus/ref_verify.h
@@ -7,15 +7,24 @@
 
 class CValidationState;
 
+namespace Consensus
+{
+    struct Params;
+}
+
 namespace referral
 {
-class Referral;
-class ReferralsViewCache;
+    class Referral;
+    class ReferralsViewCache;
 
-/** Referral validation functions */
+    /** Referral validation functions */
 
-/** Context-independent validity checks */
-bool CheckReferral(const Referral& tx, CValidationState& state);
+    /** Context-independent validity checks */
+    bool CheckReferral(
+            const Referral& referral,
+            int blockheight,
+            const Consensus::Params& params,
+            CValidationState& state);
 
 } //namespace referral
 

--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -58,47 +58,13 @@ void NormalizeAlias(std::string& alias)
     std::transform(alias.begin(), alias.end(), alias.begin(), ::tolower);
 }
 
-bool TransposeEqual(const std::string& a, const std::string& b) {
-    assert(a.size() > 1);
-    assert(a.size() == b.size());
-
-    if (a[0] != b[0] &&
-        a[1] != b[1] &&
-        a[0] != b[1] &&
-        a[1] != b[0]) {
-
-        return false;
-    }
-
-    for (int c = 2; c < a.size(); c++) {
-        if (a[c]   != b[c] &&
-            a[c-1] != b[c] &&
-            a[c]   != b[c-1]) {
-
-            return false;
-        }
-    }
-
-    return true;
-}
-
 bool AliasesEqual(std::string a, std::string b, bool safe) {
-    if(!safe) {
-        return a == b;
+    if(safe) {
+        NormalizeAlias(a);
+        NormalizeAlias(b);
     }
 
-    NormalizeAlias(a);
-    NormalizeAlias(b);
-
-    if(a.size() != b.size()) {
-        return false;
-    }
-
-    if(a == b) {
-        return true;
-    }
-
-    return TransposeEqual(a, b);
+    return a == b;
 }
 
 bool CheckReferralAliasSafe(std::string alias) {

--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -37,9 +37,9 @@ namespace referral
          * Only lowercase and exclude 0 and 1 to help reduce risk of homoglyph attacks
          * since '0' looks like 'o' and '1' looks like 'l'
          *
-         * This leaves the name space to have a size of 36^27
+         * This leaves the name space to have a size of (34^2)*(36^28)
          */
-        const std::regex SAFER_ALIAS_REGEX(strprintf("^([a-z2-9_-]){3,%d}$", BIGGER_MAX_ALIAS_LENGTH));
+        const std::regex SAFER_ALIAS_REGEX(strprintf("^[a-z2-9]([a-z2-9_-]){1,%d}[a-z2-9]$", BIGGER_MAX_ALIAS_LENGTH));
     }
 
 void NormalizeAlias(std::string& alias)

--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -39,7 +39,7 @@ namespace referral
          *
          * This leaves the name space to have a size of (34^2)*(36^28)
          */
-        const std::regex SAFER_ALIAS_REGEX(strprintf("^[a-z2-9]([a-z2-9_-]){1,%d}[a-z2-9]$", BIGGER_MAX_ALIAS_LENGTH));
+        const std::regex SAFER_ALIAS_REGEX(strprintf("^[a-z0-9]([a-z0-9_-]){1,%d}[a-z0-9]$", MAX_ALIAS_LENGTH));
     }
 
 void NormalizeAlias(std::string& alias)

--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -58,6 +58,46 @@ void NormalizeAlias(std::string& alias)
     std::transform(alias.begin(), alias.end(), alias.begin(), ::tolower);
 }
 
+bool TransposeEqual(const std::string& a, const std::string& b) {
+    assert(a.size() > 1);
+    assert(a.size() == b.size());
+
+    if (a[0] != b[0] &&
+        a[1] != b[1] &&
+        a[0] != b[1] &&
+        a[1] != b[0]) {
+
+        return false;
+    }
+
+    for (int c = 2; c < a.size(); c++) {
+        if (a[c]   != b[c] &&
+            a[c-1] != b[c] &&
+            a[c]   != b[c-1]) {
+
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool AliasesEqual(std::string a, std::string b) {
+    NormalizeAlias(a);
+    NormalizeAlias(b);
+
+    if(a.size() != b.size()) {
+        return false;
+    }
+
+    if(a == b) {
+        return true;
+    }
+
+    //Check left side
+    return TransposeEqual(a, b);
+}
+
 bool CheckReferralAliasSafe(std::string alias) {
     if(alias.empty()) {
         return true;

--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -94,7 +94,6 @@ bool AliasesEqual(std::string a, std::string b) {
         return true;
     }
 
-    //Check left side
     return TransposeEqual(a, b);
 }
 

--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -39,7 +39,7 @@ namespace referral
          *
          * This leaves the name space to have a size of (34^2)*(36^28)
          */
-        const std::regex SAFER_ALIAS_REGEX(strprintf("^[a-z0-9]([a-z0-9_-]){1,%d}[a-z0-9]$", MAX_ALIAS_LENGTH));
+        const std::regex SAFER_ALIAS_REGEX(strprintf("^[a-z0-9]([a-z0-9_-]){1,%d}[a-z0-9]$", SAFER_MAX_ALIAS_LENGTH));
     }
 
 void NormalizeAlias(std::string& alias)
@@ -79,12 +79,9 @@ bool CheckReferralAliasSafe(std::string alias) {
     return INVALID_ALIAS_NAMES.count(alias) == 0;
 }
 
-bool CheckReferralAlias(
-        std::string alias,
-        int blockheight,
-        const Consensus::Params& params)
+bool CheckReferralAlias(std::string alias, bool normalize_alias)
 {
-    if(blockheight >= params.safer_alias_blockheight) {
+    if(normalize_alias) {
         return CheckReferralAliasSafe(alias);
     }
 

--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -82,7 +82,11 @@ bool TransposeEqual(const std::string& a, const std::string& b) {
     return true;
 }
 
-bool AliasesEqual(std::string a, std::string b) {
+bool AliasesEqual(std::string a, std::string b, bool safe) {
+    if(!safe) {
+        return a == b;
+    }
+
     NormalizeAlias(a);
     NormalizeAlias(b);
 

--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -28,6 +28,10 @@ struct MutableReferral;
 
 static const int MAX_ALIAS_LENGTH = 20;
 
+//This is 2 less than MAX_ALIAS_LENGTH because the SAFER_ALIAS_REGEX validates
+//the other 2 characters. So the ultimate length stays the same.
+static const int SAFER_MAX_ALIAS_LENGTH = 18;
+
 struct MutableReferral;
 
 /** The basic referral that is broadcast on the network and contained in
@@ -252,10 +256,7 @@ static inline ReferralRef MakeReferralRef(Ref&& referralIn)
  * It must not be greater than a certain size and not use certain
  * blacklisted words
  */
-bool CheckReferralAlias(
-        std::string ref,
-        int blockheight,
-        const Consensus::Params&);
+bool CheckReferralAlias(std::string ref, bool normalize_alias);
 
 /**
  * Safe version of CheckReferralAlias that assumes the new safety rules.

--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -274,8 +274,9 @@ void NormalizeAlias(std::string& alias);
 /**
  * Returns true if the two aliases are equal. The aliases are compared
  * in normalize form. Also a transpose check is done on either side.
+ * unless safe mode off, then it's just a byte compare.
  */
-bool AliasesEqual(std::string a, std::string b);
+bool AliasesEqual(std::string a, std::string b, bool safe);
 
 } //namespace referral
 

--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -5,6 +5,7 @@
 #ifndef MERIT_PRIMITIVES_REFERRAL_H
 #define MERIT_PRIMITIVES_REFERRAL_H
 
+#include "consensus/params.h"
 #include "hash.h"
 #include "pubkey.h"
 #include "script/script.h"
@@ -26,6 +27,7 @@ using ReferralId = boost::variant<uint256, referral::Address, std::string>;
 struct MutableReferral;
 
 static const int MAX_ALIAS_LENGTH = 20;
+static const int BIGGER_MAX_ALIAS_LENGTH = 30;
 
 struct MutableReferral;
 
@@ -251,7 +253,23 @@ static inline ReferralRef MakeReferralRef(Ref&& referralIn)
  * It must not be greater than a certain size and not use certain
  * blacklisted words
  */
-bool CheckReferralAlias(std::string ref);
+bool CheckReferralAlias(
+        std::string ref,
+        int blockheight,
+        const Consensus::Params&);
+
+/**
+ * Safe version of CheckReferralAlias that assumes the new safety rules.
+ */
+bool CheckReferralAliasSafe(std::string alias);
+
+/**
+ * Normalizes an alias to a form that can compared and stored.
+ * This function is safe to handle any user input. It does not validate
+ * if the alias is a valid one, you must use CheckReferralAlias after
+ * normalization to decide if the alias is valid.
+ */
+void NormalizeAlias(std::string& alias);
 
 } //namespace referral
 

--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -271,6 +271,12 @@ bool CheckReferralAliasSafe(std::string alias);
  */
 void NormalizeAlias(std::string& alias);
 
+/**
+ * Returns true if the two aliases are equal. The aliases are compared
+ * in normalize form. Also a transpose check is done on either side.
+ */
+bool AliasesEqual(std::string a, std::string b);
+
 } //namespace referral
 
 

--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -27,7 +27,7 @@ using ReferralId = boost::variant<uint256, referral::Address, std::string>;
 struct MutableReferral;
 
 static const int MAX_ALIAS_LENGTH = 20;
-static const int BIGGER_MAX_ALIAS_LENGTH = 30;
+static const int BIGGER_MAX_ALIAS_LENGTH = 28;
 
 struct MutableReferral;
 

--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -27,7 +27,6 @@ using ReferralId = boost::variant<uint256, referral::Address, std::string>;
 struct MutableReferral;
 
 static const int MAX_ALIAS_LENGTH = 20;
-static const int BIGGER_MAX_ALIAS_LENGTH = 28;
 
 struct MutableReferral;
 

--- a/src/qt/enterunlockcode.cpp
+++ b/src/qt/enterunlockcode.cpp
@@ -122,7 +122,7 @@ void EnterUnlockCode::aliasChanged(const QString &newText)
 {
     auto alias = newText.toStdString();
 
-    bool valid = alias.empty() || referral::CheckReferralAlias(alias);
+    bool valid = referral::CheckReferralAliasSafe(alias);
     bool taken = !alias.empty() && walletModel->AliasExists(alias);
 
     aliasValid = valid && !taken;

--- a/src/refdb.cpp
+++ b/src/refdb.cpp
@@ -100,13 +100,13 @@ namespace referral
 
         Address address;
 
-        auto normalized = alias;
+        auto maybe_normalized = alias;
 
         if (normalize_alias) {
-            NormalizeAlias(normalized);
+            NormalizeAlias(maybe_normalized);
         }
 
-        if (m_db.Read(std::make_pair(DB_ALIAS, normalized), address)) {
+        if (m_db.Read(std::make_pair(DB_ALIAS, maybe_normalized), address)) {
             return GetReferral(address);
         }
 
@@ -181,12 +181,12 @@ namespace referral
 
         if (referral.version >= Referral::INVITE_VERSION && referral.alias.size() > 0) {
             // write referral referral address by alias
-            auto normalized = referral.alias;
+            auto maybe_normalized = referral.alias;
             if (normalize_alias) {
-                NormalizeAlias(normalized);
+                NormalizeAlias(maybe_normalized);
             }
 
-            if (!m_db.Write(std::make_pair(DB_ALIAS, normalized), referral.GetAddress())) {
+            if (!m_db.Write(std::make_pair(DB_ALIAS, maybe_normalized), referral.GetAddress())) {
                 return false;
             }
         }
@@ -914,13 +914,13 @@ namespace referral
             const std::string& alias, 
             bool normalize_alias) const
     {
-        auto normalized = alias;
+        auto maybe_normalized = alias;
         if (normalize_alias) {
-            NormalizeAlias(normalized);
+            NormalizeAlias(maybe_normalized);
         }
 
-        return normalized.size() > 0 &&
-            m_db.Exists(std::make_pair(DB_ALIAS, normalized));
+        return maybe_normalized.size() > 0 &&
+            m_db.Exists(std::make_pair(DB_ALIAS, maybe_normalized));
     }
 
     bool ReferralsViewDB::IsConfirmed(const referral::Address& address) const

--- a/src/refdb.cpp
+++ b/src/refdb.cpp
@@ -46,8 +46,21 @@ namespace referral
         {
             private:
                 const ReferralsViewDB *db;
+                const int blockheight;
+                const Consensus::Params& params;
+
             public:
-                explicit ReferralIdVisitor(const ReferralsViewDB *db_in): db{db_in} {}
+                ReferralIdVisitor(
+                        const ReferralsViewDB *db_in,
+                        int blockheight_in,
+                        const Consensus::Params& params_in) : 
+                    db{db_in},
+                    blockheight{blockheight_in},
+                    params{params_in} {}
+
+                MaybeReferral operator()(const std::string &id) const {
+                    return db->GetReferral(id, blockheight, params);
+                }
 
                 template <typename T>
                     MaybeReferral operator()(const T &id) const {
@@ -117,9 +130,13 @@ namespace referral
         return {};
     }
 
-    MaybeReferral ReferralsViewDB::GetReferral(const ReferralId& referral_id) const
+    MaybeReferral ReferralsViewDB::GetReferral(
+            const ReferralId& referral_id,
+            int blockheight,
+            const Consensus::Params& params) const
     {
-        return boost::apply_visitor(ReferralIdVisitor(this), referral_id);
+        return boost::apply_visitor(
+                ReferralIdVisitor{this, blockheight, params}, referral_id);
     }
 
 

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -86,7 +86,12 @@ public:
 
     MaybeReferral GetReferral(const Address&) const;
     MaybeReferral GetReferral(const uint256&) const;
-    MaybeReferral GetReferral(const std::string&) const;
+
+    MaybeReferral GetReferral(
+            const std::string&,
+            int blockheight,
+            const Consensus::Params& params) const;
+
     MaybeReferral GetReferral(const ReferralId&) const;
     MaybeAddressPair GetParentAddress(const Address&) const;
     MaybeAddress GetAddressByPubKey(const CPubKey&) const;
@@ -97,7 +102,11 @@ public:
     AddressANVs GetAllANVs() const;
     bool OrderReferrals(referral::ReferralRefs& refs);
 
-    bool InsertReferral(const Referral&, bool allow_no_parent = false);
+    bool InsertReferral(
+            const Referral&,
+            bool allow_no_parent,
+            int blockheight,
+            const Consensus::Params&);
     bool RemoveReferral(const Referral&);
 
     void GetAllRewardableANVs(
@@ -119,7 +128,15 @@ public:
 
     //Daedalus code.
     bool Exists(const Address&) const;
-    bool Exists(const std::string&) const;
+
+    /**
+     * Check if a referral exists by alias.
+     */
+    bool Exists(
+            const std::string& alias,
+            int blockheight,
+            const Consensus::Params& params) const;
+
     bool IsConfirmed(const Address&) const;
     bool UpdateConfirmation(char address_type, const Address&, CAmount amount);
 

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -92,7 +92,11 @@ public:
             int blockheight,
             const Consensus::Params& params) const;
 
-    MaybeReferral GetReferral(const ReferralId&) const;
+    MaybeReferral GetReferral(
+            const ReferralId&,
+            int blockheight,
+            const Consensus::Params& params) const;
+
     MaybeAddressPair GetParentAddress(const Address&) const;
     MaybeAddress GetAddressByPubKey(const CPubKey&) const;
     ChildAddresses GetChildren(const Address&) const;

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -90,12 +90,14 @@ public:
     MaybeReferral GetReferral(
             const std::string&,
             int blockheight,
-            const Consensus::Params& params) const;
+            const Consensus::Params& params,
+            bool transpose_check = true) const;
 
     MaybeReferral GetReferral(
             const ReferralId&,
             int blockheight,
-            const Consensus::Params& params) const;
+            const Consensus::Params& params,
+            bool transpose_check = true) const;
 
     MaybeAddressPair GetParentAddress(const Address&) const;
     MaybeAddress GetAddressByPubKey(const CPubKey&) const;
@@ -139,7 +141,8 @@ public:
     bool Exists(
             const std::string& alias,
             int blockheight,
-            const Consensus::Params& params) const;
+            const Consensus::Params& params,
+            bool transpose_check = true) const;
 
     bool IsConfirmed(const Address&) const;
     bool UpdateConfirmation(char address_type, const Address&, CAmount amount);

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -90,14 +90,12 @@ public:
     MaybeReferral GetReferral(
             const std::string&,
             int blockheight,
-            const Consensus::Params& params,
-            bool transpose_check = true) const;
+            const Consensus::Params& params) const;
 
     MaybeReferral GetReferral(
             const ReferralId&,
             int blockheight,
-            const Consensus::Params& params,
-            bool transpose_check = true) const;
+            const Consensus::Params& params) const;
 
     MaybeAddressPair GetParentAddress(const Address&) const;
     MaybeAddress GetAddressByPubKey(const CPubKey&) const;
@@ -141,8 +139,7 @@ public:
     bool Exists(
             const std::string& alias,
             int blockheight,
-            const Consensus::Params& params,
-            bool transpose_check = true) const;
+            const Consensus::Params& params) const;
 
     bool IsConfirmed(const Address&) const;
     bool UpdateConfirmation(char address_type, const Address&, CAmount amount);

--- a/src/refdb.h
+++ b/src/refdb.h
@@ -89,13 +89,11 @@ public:
 
     MaybeReferral GetReferral(
             const std::string&,
-            int blockheight,
-            const Consensus::Params& params) const;
+            bool normalize_alias) const;
 
     MaybeReferral GetReferral(
             const ReferralId&,
-            int blockheight,
-            const Consensus::Params& params) const;
+            bool normalize_alias) const;
 
     MaybeAddressPair GetParentAddress(const Address&) const;
     MaybeAddress GetAddressByPubKey(const CPubKey&) const;
@@ -109,8 +107,8 @@ public:
     bool InsertReferral(
             const Referral&,
             bool allow_no_parent,
-            int blockheight,
-            const Consensus::Params&);
+            bool normalize_alias);
+
     bool RemoveReferral(const Referral&);
 
     void GetAllRewardableANVs(
@@ -136,10 +134,7 @@ public:
     /**
      * Check if a referral exists by alias.
      */
-    bool Exists(
-            const std::string& alias,
-            int blockheight,
-            const Consensus::Params& params) const;
+    bool Exists(const std::string& alias, bool normalize_alias) const;
 
     bool IsConfirmed(const Address&) const;
     bool UpdateConfirmation(char address_type, const Address&, CAmount amount);

--- a/src/referrals.cpp
+++ b/src/referrals.cpp
@@ -65,26 +65,25 @@ bool ReferralsViewCache::Exists(const Address& address) const
 
 bool ReferralsViewCache::Exists(
         const std::string& alias,
-        int blockheight,
-        const Consensus::Params& params) const
+        bool normalize_alias) const
 {
     if (alias.size() == 0) {
         return false;
     }
 
-    auto normalized_alias = alias;
-    if(blockheight >= params.safer_alias_blockheight) {
-        NormalizeAlias(normalized_alias);
+    auto normalized = alias;
+    if(normalize_alias) {
+        NormalizeAlias(normalized);
     } 
 
     {
         LOCK(m_cs_cache);
-        if (referrals_index.get<by_alias>().count(normalized_alias) > 0) {
+        if (referrals_index.get<by_alias>().count(normalized) > 0) {
             return true;
         }
     }
 
-    if (auto ref = m_db->GetReferral(normalized_alias, blockheight, params)) {
+    if (auto ref = m_db->GetReferral(normalized, normalize_alias)) {
         InsertReferralIntoCache(*ref);
         return true;
     }

--- a/src/referrals.cpp
+++ b/src/referrals.cpp
@@ -72,30 +72,19 @@ bool ReferralsViewCache::Exists(
         return false;
     }
 
+    auto normalized_alias = alias;
+    if(blockheight >= params.safer_alias_blockheight) {
+        NormalizeAlias(normalized_alias);
+    } 
+
     {
         LOCK(m_cs_cache);
-        if(blockheight >= params.safer_alias_blockheight) {
-            auto normalized_alias = alias;
-            NormalizeAlias(normalized_alias);
-
-            if (referrals_index.get<by_alias>().count(normalized_alias) > 0) {
-                return true;
-            }
-
-            for (int c = 1; c < normalized_alias.size(); c++) {
-                std::swap(normalized_alias[c-1], normalized_alias[c]);
-                if (referrals_index.get<by_alias>().count(normalized_alias) > 0) {
-                    return true;
-                }
-                std::swap(normalized_alias[c-1], normalized_alias[c]);
-            }
-        } else {
-            if (referrals_index.get<by_alias>().count(alias) > 0) {
-                return true;
-            }
+        if (referrals_index.get<by_alias>().count(normalized_alias) > 0) {
+            return true;
         }
     }
-    if (auto ref = m_db->GetReferral(alias, blockheight, params)) {
+
+    if (auto ref = m_db->GetReferral(normalized_alias, blockheight, params)) {
         InsertReferralIntoCache(*ref);
         return true;
     }

--- a/src/referrals.cpp
+++ b/src/referrals.cpp
@@ -71,19 +71,19 @@ bool ReferralsViewCache::Exists(
         return false;
     }
 
-    auto normalized = alias;
+    auto maybe_normalized = alias;
     if(normalize_alias) {
-        NormalizeAlias(normalized);
+        NormalizeAlias(maybe_normalized);
     } 
 
     {
         LOCK(m_cs_cache);
-        if (referrals_index.get<by_alias>().count(normalized) > 0) {
+        if (referrals_index.get<by_alias>().count(maybe_normalized) > 0) {
             return true;
         }
     }
 
-    if (auto ref = m_db->GetReferral(normalized, normalize_alias)) {
+    if (auto ref = m_db->GetReferral(maybe_normalized, normalize_alias)) {
         InsertReferralIntoCache(*ref);
         return true;
     }

--- a/src/referrals.h
+++ b/src/referrals.h
@@ -86,7 +86,10 @@ public:
     bool Exists(const uint256&) const;
 
     /** Check if referral alias occupied */
-    bool Exists(const std::string&) const;
+    bool Exists(
+            const std::string& alias,
+            int blockheight,
+            const Consensus::Params& params) const;
 
     /** Remove referral from cache */
     bool RemoveReferral(const Referral&) const;

--- a/src/referrals.h
+++ b/src/referrals.h
@@ -86,10 +86,7 @@ public:
     bool Exists(const uint256&) const;
 
     /** Check if referral alias occupied */
-    bool Exists(
-            const std::string& alias,
-            int blockheight,
-            const Consensus::Params& params) const;
+    bool Exists( const std::string& alias, bool normalize_alias) const;
 
     /** Remove referral from cache */
     bool RemoveReferral(const Referral&) const;

--- a/src/refmempool.cpp
+++ b/src/refmempool.cpp
@@ -292,7 +292,6 @@ bool ReferralTxMemPool::Exists(const std::string& alias) const
     auto normalized_alias = alias;
     NormalizeAlias(normalized_alias);
 
-    //Try exact match first
     if(mapRTx.get<referral_alias>().count(normalized_alias) != 0) {
         return true;
     }

--- a/src/refmempool.cpp
+++ b/src/refmempool.cpp
@@ -245,16 +245,6 @@ ReferralRef ReferralTxMemPool::Get(const std::string& alias) const
         return it->GetSharedEntryValue();
     }
 
-    //Search by transposing each adjacent pair which is done for the DB search.
-    for (int c = 1; c < normalized_alias.size(); c++) {
-        std::swap(normalized_alias[c-1], normalized_alias[c]);
-        it = mapRTx.get<referral_alias>().find(normalized_alias);
-        if(it != mapRTx.get<referral_alias>().end()) {
-            return it->GetSharedEntryValue();
-        }
-        std::swap(normalized_alias[c-1], normalized_alias[c]);
-    }
-
     return nullptr;
 }
 
@@ -271,15 +261,6 @@ std::pair<ReferralTxMemPool::RefAliasIter, ReferralTxMemPool::RefAliasIter> Refe
     auto pair = mapRTx.get<referral_alias>().equal_range(normalized_alias);
     if(pair.first != mapRTx.get<referral_alias>().end()) {
         return pair;
-    }
-
-    for (int c = 1; c < normalized_alias.size(); c++) {
-        std::swap(normalized_alias[c-1], normalized_alias[c]);
-        pair = mapRTx.get<referral_alias>().equal_range(normalized_alias);
-        if(pair.first != mapRTx.get<referral_alias>().end()) {
-            return pair;
-        }
-        std::swap(normalized_alias[c-1], normalized_alias[c]);
     }
 
     return pair;
@@ -314,15 +295,6 @@ bool ReferralTxMemPool::Exists(const std::string& alias) const
     //Try exact match first
     if(mapRTx.get<referral_alias>().count(normalized_alias) != 0) {
         return true;
-    }
-
-    //Search by transposing each adjacent pair
-    for (int c = 1; c < normalized_alias.size(); c++) {
-        std::swap(normalized_alias[c-1], normalized_alias[c]);
-        if(mapRTx.get<referral_alias>().count(normalized_alias) != 0) {
-            return true;
-        }
-        std::swap(normalized_alias[c-1], normalized_alias[c]);
     }
 
     return false;

--- a/src/refmempool.cpp
+++ b/src/refmempool.cpp
@@ -25,7 +25,7 @@ const Address& GetAddress(const RefMemPoolEntry& entry)
     return entry.GetSharedEntryValue()->GetAddress();
 }
 
-const std::string& GetAlias(const RefMemPoolEntry& entry)
+std::string GetAlias(const RefMemPoolEntry& entry)
 {
     auto normalized_alias = entry.GetSharedEntryValue()->alias;
     NormalizeAlias(normalized_alias);

--- a/src/refmempool.h
+++ b/src/refmempool.h
@@ -81,7 +81,7 @@ struct referral_parent {
 };
 
 const Address& GetAddress(const RefMemPoolEntry& entry);
-const std::string& GetAlias(const RefMemPoolEntry& entry);
+std::string GetAlias(const RefMemPoolEntry& entry);
 const Address& GetParentAddress(const RefMemPoolEntry& entry);
 
 class ReferralTxMemPool
@@ -113,7 +113,7 @@ public:
                 boost::multi_index::tag<referral_alias>,
                 boost::multi_index::global_fun<
                     const RefMemPoolEntry&,
-                    const std::string&,
+                    std::string,
                     &GetAlias>>,
             boost::multi_index::hashed_non_unique<
                 boost::multi_index::tag<referral_parent>,

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -240,7 +240,7 @@ UniValue validatealias(const JSONRPCRequest& request)
 
     // alias can not be in address format
     bool is_valid = !IsValidDestination(dest);
-    is_valid &= referral::CheckReferralAlias(alias);
+    is_valid &= referral::CheckReferralAliasSafe(alias);
 
     bool is_vacant = !mempoolReferral.Exists(alias) && !prefviewcache->Exists(alias);
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -242,7 +242,12 @@ UniValue validatealias(const JSONRPCRequest& request)
     bool is_valid = !IsValidDestination(dest);
     is_valid &= referral::CheckReferralAliasSafe(alias);
 
-    bool is_vacant = !mempoolReferral.Exists(alias) && !prefviewcache->Exists(alias);
+    // assume and do the new safer rule logic.
+    const auto &params = Params().GetConsensus();
+    auto height = params.safer_alias_blockheight;
+
+    bool is_vacant = !mempoolReferral.Exists(alias) 
+        && !prefviewcache->Exists(alias, height, params);
 
     ret.push_back(Pair("isvalid", is_valid));
     ret.push_back(Pair("isvacant", is_vacant));

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -243,11 +243,8 @@ UniValue validatealias(const JSONRPCRequest& request)
     is_valid &= referral::CheckReferralAliasSafe(alias);
 
     // assume and do the new safer rule logic.
-    const auto &params = Params().GetConsensus();
-    auto height = params.safer_alias_blockheight;
-
-    bool is_vacant = !mempoolReferral.Exists(alias) 
-        && !prefviewcache->Exists(alias, height, params);
+    bool is_vacant =
+        !mempoolReferral.Exists(alias) && !prefviewcache->Exists(alias, true);
 
     ret.push_back(Pair("isvalid", is_valid));
     ret.push_back(Pair("isvacant", is_vacant));

--- a/src/rpc/rawreferral.cpp
+++ b/src/rpc/rawreferral.cpp
@@ -120,10 +120,7 @@ UniValue getrawreferral(const JSONRPCRequest& request)
         referral_id = *(address.GetUint160());
     }
 
-    ReferralRef ref;
-    ref = LookupReferral(referral_id,
-            Params().GetConsensus().safer_alias_blockheight,
-            Params().GetConsensus());
+    auto ref = LookupReferral(referral_id, true);
 
     if (!ref) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about referral");

--- a/src/rpc/rawreferral.cpp
+++ b/src/rpc/rawreferral.cpp
@@ -121,7 +121,9 @@ UniValue getrawreferral(const JSONRPCRequest& request)
     }
 
     ReferralRef ref;
-    ref = LookupReferral(referral_id);
+    ref = LookupReferral(referral_id,
+            Params().GetConsensus().safer_alias_blockheight,
+            Params().GetConsensus());
 
     if (!ref) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about referral");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5211,10 +5211,15 @@ CTxDestination LookupDestination(const std::string& address)
         return dest;
     }
 
-    // Get referral by alias from cache
-    // He we assume we are in safer mode by giving the blockheight as the safer_alias_blockheight
+    // Get referral by alias from cache.
+    // He we assume we are in safer mode by giving the blockheight as the safer_alias_blockheight.
+    // We don't do the transpose check here because LookupDestination is used for in the client
+    // code and not valiation
     auto cached_referral = prefviewdb->GetReferral(
-            address, Params().GetConsensus().safer_alias_blockheight, Params().GetConsensus());
+            address,
+            Params().GetConsensus().safer_alias_blockheight,
+            Params().GetConsensus(),
+            false);
 
     if (cached_referral) {
         return CMeritAddress{cached_referral->addressType, cached_referral->GetAddress()}.Get();
@@ -5232,13 +5237,15 @@ CTxDestination LookupDestination(const std::string& address)
     return dest;
 }
 
-const referral::ReferralRef LookupReferral(
+referral::ReferralRef LookupReferral(
         referral::ReferralId& referral_id,
         int blockheight,
         const Consensus::Params& params)
 {
+    //We don't do transpose check here because LookupReferral is used by client
+    //code retrieval not consensus. 
     auto chain_referral =
-        prefviewdb->GetReferral(referral_id, blockheight, params);
+        prefviewdb->GetReferral(referral_id, blockheight, params, false);
 
     if (chain_referral) {
         return MakeReferralRef(*chain_referral);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5219,8 +5219,7 @@ CTxDestination LookupDestination(const std::string& address)
     auto cached_referral = prefviewdb->GetReferral(
             address,
             Params().GetConsensus().safer_alias_blockheight,
-            Params().GetConsensus(),
-            false);
+            Params().GetConsensus());
 
     if (cached_referral) {
         return CMeritAddress{cached_referral->addressType, cached_referral->GetAddress()}.Get();
@@ -5246,7 +5245,7 @@ referral::ReferralRef LookupReferral(
     //We don't do transpose check here because LookupReferral is used by client
     //code retrieval not consensus. 
     auto chain_referral =
-        prefviewdb->GetReferral(referral_id, blockheight, params, false);
+        prefviewdb->GetReferral(referral_id, blockheight, params);
 
     if (chain_referral) {
         return MakeReferralRef(*chain_referral);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -422,9 +422,10 @@ bool CheckReferralAliasUnique(
     if (block != nullptr) {
         auto it = std::find_if (
             block->m_vRef.begin(), block->m_vRef.end(),
-            [&referral_in](const referral::ReferralRef& ref) {
+            [&referral_in, &params, blockheight](const referral::ReferralRef& ref) {
                 return 
-                    referral::AliasesEqual(ref->alias, referral_in->alias) &&
+                    referral::AliasesEqual(ref->alias, referral_in->alias,
+                            blockheight >= params.safer_alias_blockheight) &&
                     ref->GetHash() != referral_in->GetHash();
             });
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5399,7 +5399,7 @@ static bool ContextualCheckBlock(
 
     for (const auto& ref : block.m_vRef) {
         if (!CheckReferral(*ref, nHeight, consensusParams, state)) {
-            //statge is cet by CheckReferral
+            //state is set by CheckReferral
             return false;
         }
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -583,7 +583,7 @@ bool CheckAddressConfirmed(const CMeritAddress& addr, bool checkMempool = true);
  */
 CTxDestination LookupDestination(const std::string& address);
 
-const referral::ReferralRef LookupReferral(
+referral::ReferralRef LookupReferral(
         referral::ReferralId& referral_id,
         int blockheight,
         const Consensus::Params& params);

--- a/src/validation.h
+++ b/src/validation.h
@@ -583,7 +583,10 @@ bool CheckAddressConfirmed(const CMeritAddress& addr, bool checkMempool = true);
  */
 CTxDestination LookupDestination(const std::string& address);
 
-const referral::ReferralRef LookupReferral(referral::ReferralId& referral_id);
+const referral::ReferralRef LookupReferral(
+        referral::ReferralId& referral_id,
+        int blockheight,
+        const Consensus::Params& params);
 
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex(const CChainParams& params);

--- a/src/validation.h
+++ b/src/validation.h
@@ -585,8 +585,7 @@ CTxDestination LookupDestination(const std::string& address);
 
 referral::ReferralRef LookupReferral(
         referral::ReferralId& referral_id,
-        int blockheight,
-        const Consensus::Params& params);
+        bool normalize_alias);
 
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex(const CChainParams& params);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -210,10 +210,7 @@ referral::ReferralRef CWallet::Unlock(const referral::Address& parentAddress, co
         throw std::runtime_error(std::string(__func__) + ": the alias doesn't pass validation");
     }
 
-    if (prefviewcache->Exists(
-                alias,
-                Params().GetConsensus().safer_alias_blockheight,
-                Params().GetConsensus())) {
+    if (prefviewcache->Exists(alias, true)) {
         throw std::runtime_error(std::string(__func__) + ": provided alias is already occupied");
     }
 
@@ -246,11 +243,7 @@ referral::ReferralRef CWallet::Unlock(const referral::Address& parentAddress, co
 
 bool CWallet::AliasExists(const std::string& alias) const
 {
-    return !alias.empty() &&
-        prefviewcache->Exists(
-            alias,
-            Params().GetConsensus().safer_alias_blockheight,
-            Params().GetConsensus());
+    return !alias.empty() && prefviewcache->Exists(alias, true);
 }
 
 bool CWallet::AddressBeaconed(const CMeritAddress& address) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -206,7 +206,7 @@ referral::ReferralRef CWallet::Unlock(const referral::Address& parentAddress, co
     }
 
     // check if provided referral's alias is valid and not yet occupied
-    if(!referral::CheckReferralAlias(alias)) {
+    if(!referral::CheckReferralAliasSafe(alias)) {
         throw std::runtime_error(std::string(__func__) + ": the alias doesn't pass validation");
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -210,7 +210,10 @@ referral::ReferralRef CWallet::Unlock(const referral::Address& parentAddress, co
         throw std::runtime_error(std::string(__func__) + ": the alias doesn't pass validation");
     }
 
-    if (prefviewcache->Exists(alias)) {
+    if (prefviewcache->Exists(
+                alias,
+                Params().GetConsensus().safer_alias_blockheight,
+                Params().GetConsensus())) {
         throw std::runtime_error(std::string(__func__) + ": provided alias is already occupied");
     }
 
@@ -243,8 +246,11 @@ referral::ReferralRef CWallet::Unlock(const referral::Address& parentAddress, co
 
 bool CWallet::AliasExists(const std::string& alias) const
 {
-    if(alias.empty()) return false;
-    return prefviewcache->Exists(alias);
+    return !alias.empty() &&
+        prefviewcache->Exists(
+            alias,
+            Params().GetConsensus().safer_alias_blockheight,
+            Params().GetConsensus());
 }
 
 bool CWallet::AddressBeaconed(const CMeritAddress& address) const

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -303,7 +303,19 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssValue >> rtx;
 
             CValidationState state;
-            if (!(referral::CheckReferral(*(rtx.GetReferral()), state)
+            if (!(
+                        (
+                         referral::CheckReferral(
+                             *(rtx.GetReferral()),
+                             0,
+                             Params().GetConsensus(),
+                             state)
+                         ||
+                         referral::CheckReferral(
+                             *(rtx.GetReferral()),
+                             Params().GetConsensus().safer_alias_blockheight,
+                             Params().GetConsensus(),
+                             state))
                         && (rtx.GetHash() == hash)
                         && state.IsValid())) {
                 return false;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -303,19 +303,8 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssValue >> rtx;
 
             CValidationState state;
-            if (!(
-                        (
-                         referral::CheckReferral(
-                             *(rtx.GetReferral()),
-                             0,
-                             Params().GetConsensus(),
-                             state)
-                         ||
-                         referral::CheckReferral(
-                             *(rtx.GetReferral()),
-                             Params().GetConsensus().safer_alias_blockheight,
-                             Params().GetConsensus(),
-                             state))
+            if (!((referral::CheckReferral( *(rtx.GetReferral()), false, state)
+                   || referral::CheckReferral( *(rtx.GetReferral()), true, state))
                         && (rtx.GetHash() == hash)
                         && state.IsValid())) {
                 return false;


### PR DESCRIPTION
Restricted aliases to be more strict and safe.

1. Lookup and validation of aliases is case insensitive.
2. Aliases are normalized to a standard form internally for lookup and comparison.
