### PR TITLE
Fix confusing transition between reindexing and downloading.

### DIFF
--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -97,14 +97,20 @@ QLabel { color: rgb(40,40,40);  }</string>
            <property name="fieldGrowthPolicy">
             <enum>QFormLayout::FieldsStayAtSizeHint</enum>
            </property>
+           <property name="labelAlignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+           <property name="formAlignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           </property>
            <property name="horizontalSpacing">
             <number>6</number>
            </property>
            <property name="verticalSpacing">
-            <number>6</number>
+            <number>3</number>
            </property>
            <property name="topMargin">
-            <number>20</number>
+            <number>14</number>
            </property>
            <item row="0" column="0">
             <widget class="QLabel" name="labelSyncDone">
@@ -150,23 +156,10 @@ QLabel { color: rgb(40,40,40);  }</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="labelProgressIncrease">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#384c62;&quot;&gt;Blocks Per Hour&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-            </widget>
-           </item>
            <item row="5" column="1">
             <widget class="QLabel" name="blocksPerH">
              <property name="text">
-              <string>calculating...</string>
+              <string>Calculating...</string>
              </property>
             </widget>
            </item>
@@ -179,14 +172,27 @@ QLabel { color: rgb(40,40,40);  }</string>
               </font>
              </property>
              <property name="text">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#384c62;&quot;&gt;Estimated time left until synced&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#384c62;&quot;&gt;Estimated time left&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
             </widget>
            </item>
            <item row="6" column="1">
             <widget class="QLabel" name="expectedTimeLeft">
              <property name="text">
-              <string>calculating...</string>
+              <string>Calculating...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="labelProgressIncrease">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#384c62;&quot;&gt;Blocks Per Hour&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
             </widget>
            </item>
@@ -387,7 +393,7 @@ QLabel { color: rgb(40,40,40);  }</string>
            </property>
           </spacer>
          </item>
-         <item>
+         <item alignment="Qt::AlignHCenter">
           <widget class="QLabel" name="learnMoreLink">
            <property name="text">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt; font-style:italic; color:#222e3c;&quot;&gt;Learn more about why Merit is the world’s friendliest digital currency at &lt;/span&gt;&lt;a href=&quot;https://www.merit.me/why-merit/&quot;&gt;&lt;span style=&quot; font-size:8pt; font-style:italic; text-decoration: underline; color:#0000ff;&quot;&gt;Merit.me&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:8pt; font-style:italic;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -28,6 +28,7 @@ ModalOverlay::ModalOverlay(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ModalOverlay),
     bestHeaderHeight(0),
+    startCount(0),
     bestHeaderDate(QDateTime()),
     layerIsVisible(false),
     userClosed(false)
@@ -101,8 +102,21 @@ void ModalOverlay::setKnownBestHeight(int count, const QDateTime& blockDate)
 
 void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
 {
+    if(startCount == 0) {
+        startCount = count;
+    }
+
     QDateTime currentDate = QDateTime::currentDateTime();
-    setKnownBestHeight(count, blockDate);
+    bool done_reindexing = bestHeaderHeight > 0 && count > bestHeaderHeight && fImporting;
+    if(done_reindexing) {
+        startCount = count;
+        setKnownBestHeight(count, blockDate);
+
+        ui->labelNumberOfBlocksLeft->hide();
+        ui->labelProgressIncrease->hide();
+        ui->labelEstimatedTimeLeft->hide();
+        ui->numberOfBlocksLeft->setText("");
+    }
 
     //We want to change progress text if importing so the
     //user knows we are in reindexing stage. 
@@ -111,19 +125,23 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
         if(fImporting) {
             ui->labelSyncDone->setText(tr(
                         "<html><head/><body><p><span style=\" color:#384c62;\">"
-                        "Indexing Progress</span></p></body></html>"));
+                        "Reindexing Progress</span></p></body></html>"));
         } else {
             ui->labelSyncDone->setText(tr(
                         "<html><head/><body><p><span style=\" color:#384c62;\">"
                         "Download Progress</span></p></body></html>"));
+            ui->labelNumberOfBlocksLeft->show();
+            ui->labelProgressIncrease->show();
+            ui->labelEstimatedTimeLeft->show();
         }
         prev_importing = fImporting;
     }
 
 
     // keep a vector of samples of verification progress at height
-    double verificationProgress = bestHeaderHeight == 0 ? 0 : 
-        static_cast<double>(count) / static_cast<double>(bestHeaderHeight);
+    double verificationProgress = bestHeaderHeight - startCount <= 0 ? 0 : 
+        static_cast<double>(count - startCount) /
+        static_cast<double>(bestHeaderHeight - startCount);
 
     qint64 current_millis = currentDate.toMSecsSinceEpoch();
     block_time_samples.push_front(qMakePair(current_millis, count));
@@ -144,6 +162,7 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
             remaining_msecs = (bestHeaderHeight - count) * time_delta / blocks_delta;
 
             // show progress increase per hour
+
             ui->blocksPerH->setText(QString::number(blocks_per_hour)+tr(" (blocks/h)"));
 
             // show expected remaining time
@@ -153,9 +172,23 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
 
     // show the percentage done according to verificationProgress
     if(bestHeaderHeight == 0) {
-        ui->percentageProgress->setText(tr("Connecting..."));
+        if(fImporting) {
+            ui->percentageProgress->setText(tr("Reindexing... ") + QString::number(verificationProgress*100, 'f', 2)+"%");
+        } else {
+            ui->percentageProgress->setText(tr("Connecting..."));
+        }
     } else {
-        ui->percentageProgress->setText(QString::number(verificationProgress*100, 'f', 2)+"%");
+        if(fImporting) {
+            if(done_reindexing) {
+                ui->percentageProgress->setText(tr("Reindexing done, starting block download..."));
+                ui->blocksPerH->setText("");
+                ui->expectedTimeLeft->setText("");
+            } else {
+                ui->percentageProgress->setText(QString::number(verificationProgress*100, 'f', 2)+"%");
+            }
+        } else {
+            ui->percentageProgress->setText(QString::number(verificationProgress*100, 'f', 2)+"%");
+        }
     }
 
     ui->progressBar->setValue(verificationProgress*100);
@@ -172,10 +205,18 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
     // show remaining number of blocks
    const auto blocks_left = bestHeaderHeight - count;
    if (estimateNumHeadersLeft < HEADER_HEIGHT_DELTA_SYNC && hasBestHeader) {
-       ui->numberOfBlocksLeft->setText(tr("%1 out of %2 left...").arg(blocks_left).arg(bestHeaderHeight));
+       if(done_reindexing) {
+           ui->numberOfBlocksLeft->setText("");
+       } else {
+           ui->numberOfBlocksLeft->setText(tr("%1 out of %2 left...").arg(blocks_left).arg(bestHeaderHeight));
+       }
    } else {
        if(fImporting) {
-           ui->numberOfBlocksLeft->setText(tr("%1 out of %2 left...").arg(blocks_left).arg(bestHeaderHeight));
+           if(done_reindexing) {
+               ui->numberOfBlocksLeft->setText("");
+           } else {
+               ui->numberOfBlocksLeft->setText(tr("%1 out of %2 left...").arg(blocks_left).arg(bestHeaderHeight));
+           }
        } else {
            ui->numberOfBlocksLeft->setText(tr("Unknown. Syncing Headers (%1)...").arg(bestHeaderHeight));
        }

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -100,6 +100,20 @@ void ModalOverlay::setKnownBestHeight(int count, const QDateTime& blockDate)
     }
 }
 
+void ModalOverlay::setProgressBusy() 
+{
+    if(ui->progressBar->maximum() != 0) {
+        ui->progressBar->setMaximum(0);
+    }
+}
+  
+void ModalOverlay::setProgressActive() 
+{
+    if(ui->progressBar->maximum() != 100) {
+        ui->progressBar->setMaximum(100);
+    }
+}
+
 void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
 {
     if(startCount == 0) {
@@ -107,16 +121,6 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
     }
 
     QDateTime currentDate = QDateTime::currentDateTime();
-    bool done_reindexing = bestHeaderHeight > 0 && count > bestHeaderHeight && fImporting;
-    if(done_reindexing) {
-        startCount = count;
-        setKnownBestHeight(count, blockDate);
-
-        ui->labelNumberOfBlocksLeft->hide();
-        ui->labelProgressIncrease->hide();
-        ui->labelEstimatedTimeLeft->hide();
-        ui->numberOfBlocksLeft->setText("");
-    }
 
     //We want to change progress text if importing so the
     //user knows we are in reindexing stage. 
@@ -135,6 +139,17 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
             ui->labelEstimatedTimeLeft->show();
         }
         prev_importing = fImporting;
+    }
+
+    bool done_reindexing = bestHeaderHeight > 0 && count > bestHeaderHeight && fImporting;
+    if(done_reindexing) {
+        startCount = count;
+        setKnownBestHeight(count, blockDate);
+
+        ui->labelNumberOfBlocksLeft->hide();
+        ui->labelProgressIncrease->hide();
+        ui->labelEstimatedTimeLeft->hide();
+        ui->numberOfBlocksLeft->setText("");
     }
 
 
@@ -172,8 +187,9 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
 
     // show the percentage done according to verificationProgress
     if(bestHeaderHeight == 0) {
+        setProgressBusy();
         if(fImporting) {
-            ui->percentageProgress->setText(tr("Reindexing... ") + QString::number(verificationProgress*100, 'f', 2)+"%");
+            ui->percentageProgress->setText(tr("Reindexing... "));
         } else {
             ui->percentageProgress->setText(tr("Connecting..."));
         }
@@ -183,10 +199,13 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate)
                 ui->percentageProgress->setText(tr("Reindexing done, starting block download..."));
                 ui->blocksPerH->setText("");
                 ui->expectedTimeLeft->setText("");
+                setProgressBusy();
             } else {
+                setProgressActive();
                 ui->percentageProgress->setText(QString::number(verificationProgress*100, 'f', 2)+"%");
             }
         } else {
+            setProgressActive();
             ui->percentageProgress->setText(QString::number(verificationProgress*100, 'f', 2)+"%");
         }
     }

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -48,6 +48,7 @@ protected:
 private:
     Ui::ModalOverlay *ui;
     int bestHeaderHeight; //best known height (based on the headers)
+    int startCount;
     QDateTime bestHeaderDate;
     QVector<QPair<qint64, int> > block_time_samples;
     bool layerIsVisible;

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -46,6 +46,9 @@ protected:
     bool event(QEvent* ev);
 
 private:
+    void setProgressBusy();
+    void setProgressActive();
+
     Ui::ModalOverlay *ui;
     int bestHeaderHeight; //best known height (based on the headers)
     int startCount;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -200,6 +200,7 @@ public:
         if(statusString == "Pending" && is_daedalus) {
             const int INVITE_BUTTON_WIDTH = 80;
             QRect rect(addressRect.right() - INVITE_BUTTON_WIDTH - xpad, mainRect.top()+ypad, INVITE_BUTTON_WIDTH, halfheight);
+
             auto button_rect = painter->boundingRect(rect, tr("Send Invite"));
             button_rect.setLeft(button_rect.left() - 10);
             button_rect.setRight(button_rect.right() + 10);


### PR DESCRIPTION
During Reindexing, new headers are not downloaded until reindexing is
complete. This causes a strange behavior where the progress bar jumps back down
because the system recognized there are new headers to download.

Now the dialog clearly states when reindexing is finished and when downloading
begins.

Also downloading progress is now shown relative to when you started Merit.
So instead of showing usually 99% and up, it shows progress of downloading
remaining blocks from start to end.