### PR TITLE
Adding support for proper script multi sig addresses

### DIFF
--- a/src/merit-tx.cpp
+++ b/src/merit-tx.cpp
@@ -694,6 +694,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
 
         UpdateTransaction(mergedTx, i, sigdata);
 
+        ScriptError serror;
         if (!VerifyScript(
                     txin.scriptSig,
                     prevPubKey,
@@ -704,7 +705,8 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
                         i,
                         amount,
                         spendHeight,
-                        coin.nHeight))) {
+                        coin.nHeight),
+                    &serror)) {
             fComplete = false;
         }
     }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -84,7 +84,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "addmultisigaddress", 0, "nrequired" },
     { "addmultisigaddress", 1, "keys" },
     { "createmultisig", 0, "nrequired" },
-    { "createmultisig", 1, "keys" },
+    { "createmultisig", 2, "keys" },
     { "createvault", 1, "options" },
     { "easysend", 0, "amount" },
     { "easysend", 2, "blocktimeout" },

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -357,10 +357,12 @@ UniValue createmultisig(const JSONRPCRequest& request)
     }
 
     // Construct using pay-to-script-hash:
-    auto signing_dest = LookupDestination(request.params[1].get_str());
-    auto* signing_key_id = boost::get<CKeyID>(&signing_dest);
+    auto signing_dest = DecodeDestination(request.params[1].get_str());
+    auto signing_key_id = boost::get<CKeyID>(&signing_dest);
     if(!signing_key_id) {
-        throw std::runtime_error("The beacon signing address must be a valid public key address");
+        std::stringstream e;
+        e << "The beacon signing address must be a valid public key address: " << request.params[1].get_str();
+        throw std::runtime_error(e.str());
     }
 
     CScript redeem_script = _createmultisig_redeemScript(pwallet, request.params);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -302,7 +302,7 @@ bool VerifyScript(
         const CScriptWitness* witness,
         unsigned int flags,
         const BaseSignatureChecker& checker,
-        ScriptError* serror = nullptr);
+        ScriptError* serror);
 
 size_t CountWitnessSigOps(
         const CScript& scriptSig,

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -266,13 +266,15 @@ bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPu
     sigdata.scriptSig = PushAll(result);
 
     // Test solution
+    ScriptError serror;
     bool ss =
         solved &&
         VerifyScript(sigdata.scriptSig,
                 fromPubKey,
                 &sigdata.scriptWitness,
                 STANDARD_SCRIPT_VERIFY_FLAGS,
-                creator.Checker());
+                creator.Checker(),
+                &serror);
 
     return ss;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2759,8 +2759,9 @@ public:
             // This check is to make sure that the script we created can actually be solved for and signed by us
             // if we were to have the private keys. This is just to make sure that the script is valid and that,
             // if found in a transaction, we would still accept and relay that transaction.
+            ScriptError serror;
             if (!ProduceSignature(DummySignatureCreator(pwallet), witscript, sigs) ||
-                !VerifyScript(sigs.scriptSig, witscript, &sigs.scriptWitness, MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, DummySignatureCreator(pwallet).Checker())) {
+                !VerifyScript(sigs.scriptSig, witscript, &sigs.scriptWitness, MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, DummySignatureCreator(pwallet).Checker(), &serror)) {
                 return false;
             }
             result = CScriptID(witscript);
@@ -2784,8 +2785,9 @@ public:
             // This check is to make sure that the script we created can actually be solved for and signed by us
             // if we were to have the private keys. This is just to make sure that the script is valid and that,
             // if found in a transaction, we would still accept and relay that transaction.
+            ScriptError serror;
             if (!ProduceSignature(DummySignatureCreator(pwallet), witscript, sigs) ||
-                !VerifyScript(sigs.scriptSig, witscript, &sigs.scriptWitness, MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, DummySignatureCreator(pwallet).Checker())) {
+                !VerifyScript(sigs.scriptSig, witscript, &sigs.scriptWitness, MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, DummySignatureCreator(pwallet).Checker(), &serror)) {
                 return false;
             }
             result = CScriptID(witscript);
@@ -2809,8 +2811,9 @@ public:
             // This check is to make sure that the script we created can actually be solved for and signed by us
             // if we were to have the private keys. This is just to make sure that the script is valid and that,
             // if found in a transaction, we would still accept and relay that transaction.
+            ScriptError serror;
             if (!ProduceSignature(DummySignatureCreator(pwallet), witscript, sigs) ||
-                !VerifyScript(sigs.scriptSig, witscript, &sigs.scriptWitness, MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, DummySignatureCreator(pwallet).Checker())) {
+                !VerifyScript(sigs.scriptSig, witscript, &sigs.scriptWitness, MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_WITNESS_PUBKEYTYPE, DummySignatureCreator(pwallet).Checker(), &serror)) {
                 return false;
             }
             result = CScriptID(witscript);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2694,29 +2694,29 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
     {
-        std::string msg = "addmultisigaddress nrequired [\"key\",...] ( \"account\" )\n"
+        std::string msg = "addmultisigaddress nrequired signingaddress [\"key\",...] ( \"account\" )\n"
             "\nAdd a nrequired-to-sign multisignature address to the wallet.\n"
             "Each key is a Merit address or hex-encoded public key.\n"
             "If 'account' is specified (DEPRECATED), assign address to that account.\n"
 
             "\nArguments:\n"
             "1. nrequired        (numeric, required) The number of required signatures out of the n keys or addresses.\n"
-            "2. \"keys\"         (string, required) A json array of merit addresses or hex-encoded public keys\n"
+            "2. signingaddress   (string, required) The address of the public key used to sign the beacon for the multisig address.\n"
+            "3. \"keys\"         (string, required) A json array of merit addresses or hex-encoded public keys\n"
             "     [\n"
             "       \"address\"  (string) merit address or hex-encoded public key\n"
             "       ...,\n"
             "     ]\n"
-            "2. \"script referral pubkey id\" (string) Pub key Id used to refer the script\n"
-            "3. \"account\"      (string, optional) DEPRECATED. An account to assign the addresses to.\n"
+            "4. \"account\"      (string, optional) DEPRECATED. An account to assign the addresses to.\n"
 
             "\nResult:\n"
             "\"address\"         (string) A merit address associated with the keys.\n"
 
             "\nExamples:\n"
             "\nAdd a multisig address from 2 addresses\n"
-            + HelpExampleCli("addmultisigaddress", "2 \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"") +
+            + HelpExampleCli("addmultisigaddress", "2 16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5 \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"") +
             "\nAs json rpc call\n"
-            + HelpExampleRpc("addmultisigaddress", "2, \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"")
+            + HelpExampleRpc("addmultisigaddress", "2 16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5 \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\"")
         ;
         throw std::runtime_error(msg);
     }
@@ -2724,7 +2724,7 @@ UniValue addmultisigaddress(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
 
     uint160 scriptAddress;
-    auto scriptDest = LookupDestination(request.params[2].get_str());
+    auto scriptDest = LookupDestination(request.params[1].get_str());
     GetUint160(scriptDest, scriptAddress);
 
     std::string strAccount;


### PR DESCRIPTION
The beaconing system requires addresses to be signed with a key.
The public key address is mixed with the script address to produce a
final address for the coin.

We need to add support for this in the remaining RPC calls and merit-tx