### PR TITLE
Fix GUI not filtering out the @ symbol properly.

### DIFF
--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -42,7 +42,7 @@ namespace referral
         const std::regex SAFER_ALIAS_REGEX(strprintf("^[a-z0-9]([a-z0-9_-]){1,%d}[a-z0-9]$", SAFER_MAX_ALIAS_LENGTH));
     }
 
-void NormalizeAlias(std::string& alias)
+void CleanupAlias(std::string& alias)
 {
     boost::algorithm::trim(alias);
     if(alias.empty()) {
@@ -54,7 +54,11 @@ void NormalizeAlias(std::string& alias)
     if(alias[0] == '@') {
         alias.erase(0,1);
     }
+}
 
+void NormalizeAlias(std::string& alias)
+{
+    CleanupAlias(alias);
     std::transform(alias.begin(), alias.end(), alias.begin(), ::tolower);
 }
 

--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -252,11 +252,16 @@ static inline ReferralRef MakeReferralRef(Ref&& referralIn)
 }
 
 /**
+ * Trim an cleanup the alias text. Trims whitespace and removes the '@' symbol.
+ */
+void CleanupAlias(std::string& alias);
+
+/**
  * Returns true if the referral's alias passes validation.
  * It must not be greater than a certain size and not use certain
  * blacklisted words
  */
-bool CheckReferralAlias(std::string ref, bool normalize_alias);
+bool CheckReferralAlias(std::string alias, bool normalize_alias);
 
 /**
  * Safe version of CheckReferralAlias that assumes the new safety rules.

--- a/src/qt/faststart.cpp
+++ b/src/qt/faststart.cpp
@@ -209,6 +209,7 @@ FastStart::FastStart(const QString& data_dir,  QWidget *parent) :
     ui{new Ui::FastStart}
 {
     ui->setupUi(this);
+    this->setWindowTitle(tr("Merit"));
 
     Start();
 }
@@ -453,6 +454,7 @@ void FastStart::ExtractSnapshot()
         QTimer::singleShot(ERROR_WAIT, this, SLOT(TryAgain()));
         return;
     }
+    snapshot_output.remove();
     settings.setValue("snapshotstate", static_cast<int>(SnapshotInfo::DONE));
     QTimer::singleShot(ERROR_WAIT, this, SLOT(accept()));
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -187,7 +187,7 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
     return &(it->second);
 }
 
-referral::ReferralRef CWallet::Unlock(const referral::Address& parentAddress, const std::string alias)
+referral::ReferralRef CWallet::Unlock(const referral::Address& parentAddress, std::string alias)
 {
     // check wallet is not unlocked yet
     if (IsReferred()) {
@@ -1802,7 +1802,7 @@ referral::ReferralRef CWallet::GenerateNewReferral(
         const referral::Address& address,
         const CPubKey& signPubKey,
         const referral::Address& parentAddress,
-        const std::string alias,
+        std::string alias,
         CKey key)
 {
     if (!signPubKey.IsValid()) {
@@ -1814,6 +1814,8 @@ referral::ReferralRef CWallet::GenerateNewReferral(
         Daedalus() ?
         referral::Referral::INVITE_VERSION :
         referral::Referral::CURRENT_VERSION;
+
+    referral::CleanupAlias(alias);
 
     // generate referral for given public key
     auto referral =

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -876,7 +876,7 @@ public:
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 
     // Sets the referral address to unlock the wallet and sends referral tx to the network
-    referral::ReferralRef Unlock(const referral::Address& parentAddress, const std::string alias = "");
+    referral::ReferralRef Unlock(const referral::Address& parentAddress, std::string alias = "");
 
     bool AliasExists(const std::string& alias) const;
     bool AddressBeaconed(const CMeritAddress& address) const;
@@ -1269,25 +1269,25 @@ public:
             const referral::Address& addr,
             const CPubKey& signPubKey,
             const referral::Address& parentAddress,
-            const std::string alias = "",
+            std::string alias = "",
             CKey key = CKey{});
 
     referral::ReferralRef GenerateNewReferral(
             const CScriptID& id,
             const referral::Address& parentAddress,
             const CPubKey& signPubKey,
-            const std::string alias = "");
+            std::string alias = "");
 
     referral::ReferralRef GenerateNewReferral(
             const CParamScriptID& id,
             const referral::Address& parentAddress,
             const CPubKey& signPubKey,
-            const std::string alias = "");
+            std::string alias = "");
 
     referral::ReferralRef GenerateNewReferral(
             const CPubKey& pubkey,
             const referral::Address& parentAddress,
-            const std::string alias = "",
+            std::string alias = "",
             CKey key = CKey{});
 
     CTransactionRef SendInviteTo(const CScript& scriptPubKey, int amount = 1);


### PR DESCRIPTION
1. Filter out @ symbol and whitespace before setting the alias in a new beacon.
2. Fix for the title of the fast start dialog.
3. Remove the snapshot.zip file after extraction in fast start.