### PR TITLE
Show cleaned up alias in the rpc and UI.

### DIFF
--- a/src/primitives/referral.cpp
+++ b/src/primitives/referral.cpp
@@ -153,6 +153,13 @@ uint256 Referral::ComputeHash() const
     return SerializeHash(*this, SER_GETHASH);
 }
 
+std::string MutableReferral::GetAlias() const
+{
+    auto clean_alias = alias;
+    CleanupAlias(clean_alias);
+    return clean_alias;
+}
+
 Referral::Referral(const MutableReferral &ref) :
     version{ref.version},
     parentAddress{ref.parentAddress},
@@ -176,6 +183,13 @@ Referral::Referral(MutableReferral &&ref) :
 unsigned int Referral::GetTotalSize() const
 {
     return ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+}
+
+std::string Referral::GetAlias() const
+{
+    auto clean_alias = alias;
+    CleanupAlias(clean_alias);
+    return clean_alias;
 }
 
 std::string Referral::ToString() const

--- a/src/primitives/referral.h
+++ b/src/primitives/referral.h
@@ -106,6 +106,8 @@ public:
         return address;
     }
 
+    std::string GetAlias() const;
+
     /**
      * Get the total transaction size in bytes, including witness data.
      * "Total Size" defined in BIP141 and BIP144.
@@ -180,6 +182,8 @@ public:
     {
         Unserialize(s);
     }
+
+    std::string GetAlias() const;
 
     /**
      * Compute the hash of this MutableReferral. This is computed on the

--- a/src/qt/referralrecord.cpp
+++ b/src/qt/referralrecord.cpp
@@ -57,12 +57,12 @@ bool ShowReferral(const referral::ReferralRef& ref)
     return ref->addressType == 1;
 }
 
-ReferralRecord DecomposeReferral(const referral::ReferralRef ref, uint64_t time_received)
+ReferralRecord DecomposeReferral(const referral::ReferralRef& ref, uint64_t time_received)
 {
     assert(ref);
 
     const CMeritAddress meritAddress{ref->addressType, ref->GetAddress()};
-    return ReferralRecord{ref->GetHash(), static_cast<qint64>(time_received), meritAddress.ToString(), ref->alias};
+    return ReferralRecord{ref->GetHash(), static_cast<qint64>(time_received), meritAddress.ToString(), ref->GetAlias()};
 }
 
 /*

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -187,15 +187,16 @@ UniValue validateaddress(const JSONRPCRequest& request)
 
             // check if we have referral with the given address
             if (const auto referral = prefviewcache->GetReferral(address160)) {
-                if (referral->alias.size() > 0) {
+                auto ref_alias = referral->GetAlias();
+                if (ref_alias.size() > 0) {
                     // if referral has an alias, check if was not occupied by somebody else
                     // in case of this one was unconfirmed at some point.
-                    alias = strprintf("%s%s", referral->alias, CheckAliasUnconfirmed(address160) ? " (stale)" : "");
+                    alias = strprintf("%s%s", ref_alias, CheckAliasUnconfirmed(address160) ? " (stale)" : "");
                 }
             } else {
                 // if referral is in mempool, show it's alias
                 if (const auto mempool_referral = mempoolReferral.Get(address160)) {
-                    alias = mempool_referral->alias;
+                    alias = mempool_referral->GetAlias();
                     in_mempool = true;
                 }
             }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -85,7 +85,7 @@ void TxToJSONExpanded(const CTransaction& tx, const uint256 hashBlock, UniValue&
                 }
                 const auto maybe_referral = prefviewcache->GetReferral(spentInfo.addressHash);
                 if (maybe_referral) {
-                    in.pushKV("alias", maybe_referral->alias);
+                    in.pushKV("alias", maybe_referral->GetAlias());
                 }
             } else {
                 debug("could not fetch spent info");

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1247,8 +1247,7 @@ public:
     std::string GetAlias() const
     {
         auto ref = GetRootReferral();
-
-        return ref != nullptr ? ref->alias : "";
+        return ref != nullptr ? ref->GetAlias() : "";
     }
 
     std::string GetUnlockCode() const


### PR DESCRIPTION
It was possible to mine an alias with an '@' symbol.