### PR TITLE
make getrawtransactions not do slow search by default.

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -266,7 +266,7 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
     }
 
     bool complete_search = false;
-    if(!request.params[2].isBool()) {
+    if(!request.params[2].isNull() && request.params[2].isBool()) {
         complete_search = request.params[2].isTrue();
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -173,7 +173,7 @@ void TxToJSONExpanded(const CTransaction& tx, const uint256 hashBlock, UniValue&
 
 UniValue getrawtransaction(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
         throw std::runtime_error(
             "getrawtransaction \"txid\" ( verbose completecheck)\n"
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1621,13 +1621,13 @@ bool GetTransaction(
     }
 
     if (fAllowSlow) { // use coin database to locate block that contains transaction, and scan it
+        LOCK(cs_main);
         const Coin& coin = AccessByTxid(*pcoinsTip, hash);
         //if (!coin.IsSpent()) pindexSlow = chainActive[coin.nHeight];
         pindexSlow = chainActive[coin.nHeight];
     }
 
     if (pindexSlow) {
-        LOCK(cs_main);
         CBlock block;
         if (ReadBlockFromDisk(block, pindexSlow, consensusParams, false)) {
             std::vector<CTransactionRef> vtx;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1586,8 +1586,6 @@ bool GetTransaction(
 {
     CBlockIndex *pindexSlow = nullptr;
 
-    LOCK(cs_main);
-
     CTransactionRef ptx = mempool.get(hash);
     if (ptx)
     {
@@ -1596,7 +1594,14 @@ bool GetTransaction(
     }
 
     CDiskTxPos postx;
-    if (pblocktree->ReadTxIndex(hash, postx)) {
+
+    bool found = false;
+    {
+        LOCK(cs_main);
+        found = pblocktree->ReadTxIndex(hash, postx);
+    }
+
+    if (found) {
         CAutoFile file(OpenBlockFile(postx, true), SER_DISK, CLIENT_VERSION);
         if (file.IsNull())
             return error("%s: OpenBlockFile failed", __func__);
@@ -1622,6 +1627,7 @@ bool GetTransaction(
     }
 
     if (pindexSlow) {
+        LOCK(cs_main);
         CBlock block;
         if (ReadBlockFromDisk(block, pindexSlow, consensusParams, false)) {
             std::vector<CTransactionRef> vtx;
@@ -1645,8 +1651,6 @@ bool GetTransaction(
 /** Return transaction in txOut, and if it was found inside a block, its hash is placed in hashBlock */
 bool GetReferral(const uint256 &hash, referral::ReferralRef &refOut, uint256 &hashBlock)
 {
-    LOCK(cs_main);
-
     referral::ReferralRef mempoolref = mempoolReferral.Get(hash);
     if (mempoolref) {
         refOut = mempoolref;
@@ -1654,7 +1658,13 @@ bool GetReferral(const uint256 &hash, referral::ReferralRef &refOut, uint256 &ha
     }
 
     CDiskTxPos posref;
-    if (pblocktree->ReadReferralIndex(hash, posref)) {
+    bool found = false;
+    {
+        LOCK(cs_main);
+        found = pblocktree->ReadReferralIndex(hash, posref);
+    }
+
+    if (found) {
         CAutoFile file(OpenBlockFile(posref, true), SER_DISK, CLIENT_VERSION);
         if (file.IsNull())
             return error("%s: OpenBlockFile failed", __func__);


### PR DESCRIPTION
Don't do the slow utxo check in getrawtransaction if a transaction is not found by default. Added a parameter to enable the slow check if the user really, really wants to (but they won't want to).

Also updated the locks to cs_main to be held for a shorter amount of time in GetTransaction and GetReferral