### PR TITLE
Qt - disable "Export wallet" for wallets with no mnemonic

### DIFF
--- a/src/qt/meritgui.cpp
+++ b/src/qt/meritgui.cpp
@@ -372,8 +372,10 @@ void MeritGUI::createActions()
     backupWalletAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
 #ifdef USE_QRCODE
-    exportWalletQRAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Export Wallet..."), this);
-    exportWalletQRAction->setStatusTip(tr("Export wallet to another device"));
+    if(hasMnemonic) {
+        exportWalletQRAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Export Wallet..."), this);
+        exportWalletQRAction->setStatusTip(tr("Export wallet to another device"));
+    }
 #endif
     changePassphraseAction = new QAction(platformStyle->TextColorIcon(":/icons/key"), tr("&Change Passphrase..."), this);
     changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
@@ -583,8 +585,10 @@ bool MeritGUI::addWallet(const QString& name, WalletModel *_walletModel)
     walletModel = _walletModel;
     assert(walletModel);
 
+    hasMnemonic = walletModel->hasMnemonic();
     #ifdef USE_QRCODE
-        exportWalletDialog = new ExportWalletDialog(this, walletModel);
+        if(hasMnemonic)
+            exportWalletDialog = new ExportWalletDialog(this, walletModel);
     #endif
 
     isReferred = walletModel->IsReferred();
@@ -651,6 +655,7 @@ void MeritGUI::setWalletActionsEnabled(bool enabled, bool isReferred)
     usedReceivingAddressesAction->setEnabled(enabled);
     openAction->setEnabled(enabled);
     #ifdef USE_QRCODE
+    if(hasMnemonic)
         exportWalletQRAction->setEnabled(enabled);
     #endif
 }
@@ -756,6 +761,7 @@ void MeritGUI::showHelpMessageClicked()
 void MeritGUI::showExportWallet()
 {
     #ifdef USE_QRCODE
+    if(hasMnemonic)
         exportWalletDialog->show();
     #endif
 }

--- a/src/qt/meritgui.cpp
+++ b/src/qt/meritgui.cpp
@@ -372,10 +372,8 @@ void MeritGUI::createActions()
     backupWalletAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
     backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
 #ifdef USE_QRCODE
-    if(hasMnemonic) {
-        exportWalletQRAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Export Wallet..."), this);
-        exportWalletQRAction->setStatusTip(tr("Export wallet to another device"));
-    }
+    exportWalletQRAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Export Wallet..."), this);
+    exportWalletQRAction->setStatusTip(tr("Export wallet to another device"));
 #endif
     changePassphraseAction = new QAction(platformStyle->TextColorIcon(":/icons/key"), tr("&Change Passphrase..."), this);
     changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
@@ -655,8 +653,7 @@ void MeritGUI::setWalletActionsEnabled(bool enabled, bool isReferred)
     usedReceivingAddressesAction->setEnabled(enabled);
     openAction->setEnabled(enabled);
     #ifdef USE_QRCODE
-    if(hasMnemonic)
-        exportWalletQRAction->setEnabled(enabled);
+        exportWalletQRAction->setEnabled(enabled && hasMnemonic);
     #endif
 }
 

--- a/src/qt/meritgui.cpp
+++ b/src/qt/meritgui.cpp
@@ -587,6 +587,7 @@ bool MeritGUI::addWallet(const QString& name, WalletModel *_walletModel)
     #ifdef USE_QRCODE
         if(hasMnemonic)
             exportWalletDialog = new ExportWalletDialog(this, walletModel);
+        exportWalletQRAction->setVisible(hasMnemonic);
     #endif
 
     isReferred = walletModel->IsReferred();

--- a/src/qt/meritgui.h
+++ b/src/qt/meritgui.h
@@ -136,6 +136,7 @@ private:
     int spinnerFrame;
 
     bool isReferred = false;
+    bool hasMnemonic = false;
 
     const PlatformStyle *platformStyle;
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -699,6 +699,12 @@ bool WalletModel::getPrivKey(const CKeyID &address, CKey& vchPrivKeyOut) const
     return wallet->GetKey(address, vchPrivKeyOut);
 }
 
+bool WalletModel::hasMnemonic() const
+{
+    assert(wallet);
+    return wallet->HasMnemonic();
+}
+
 QString WalletModel::getMnemonic() const
 {
     assert(wallet);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -211,6 +211,7 @@ public:
     bool IsSpendable(const CTxDestination& dest) const;
     bool getPrivKey(const CKeyID &address, CKey& vchPrivKeyOut) const;
     void getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs);
+    bool hasMnemonic() const;
     QString getMnemonic() const;
     bool isSpent(const COutPoint& outpoint) const;
     void listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1760,9 +1760,14 @@ CPubKey CWallet::GenerateMasterKeyFromMnemonic(const WordList& mnemonic, const s
     return pubkey;
 }
 
+bool CWallet::HasMnemonic()
+{
+    return mapKeyMetadata[hdChain.masterKeyID].nVersion >= CKeyMetadata::VERSION_WITH_MNEMONIC;
+}
+
 std::string CWallet::GetMnemonic()
 {
-    if(mapKeyMetadata[hdChain.masterKeyID].nVersion >= CKeyMetadata::VERSION_WITH_MNEMONIC)
+    if(HasMnemonic())
         return mapKeyMetadata[hdChain.masterKeyID].mnemonic;
     return "";
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1218,6 +1218,7 @@ public:
     void postInitProcess(CScheduler& scheduler);
 
     bool BackupWallet(const std::string& strDest);
+    bool HasMnemonic();
     std::string GetMnemonic();
 
     /* Set the HD chain model (chain child index counters) */


### PR DESCRIPTION
users with wallets created prior to mnemonic support should not be able to see the export wallet menu item.