### PR TITLE
Fix invite coin control when wallet has many keys.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2310,6 +2310,8 @@ CAmount CWalletTx::GetImmatureCredit(bool fUseCache) const
 
 CAmount CWalletTx::GetAvailableCredit(AddressAmountMap& address_amounts, bool fUseCache) const
 {
+    assert(address_amounts.empty());
+
     if (pwallet == nullptr)
         return 0;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2507,6 +2507,12 @@ void CWallet::ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman
  * @{
  */
 
+void ReduceAddressAmounts(AddressAmountMap& result, const AddressAmountMap& other) {
+    for (const auto& a : other) {
+        result[a.first] += a.second;
+    }
+}
+
 CAmount CWallet::GetBalance(bool invite) const
 {
     CAmount nTotal = 0;
@@ -2519,7 +2525,7 @@ CAmount CWallet::GetBalance(bool invite) const
             if (pcoin->IsTrusted() && pcoin->IsInvite() == invite) {
                 AddressAmountMap tx_address_amounts;
                 nTotal += pcoin->GetAvailableCredit(tx_address_amounts);
-                address_amounts.insert(tx_address_amounts.begin(), tx_address_amounts.end());
+                ReduceAddressAmounts(address_amounts, tx_address_amounts);
             }
         }
     }
@@ -2614,7 +2620,7 @@ CAmount CWallet::GetUnconfirmedBalance(bool invite) const
 
                 AddressAmountMap tx_address_amounts;
                 nTotal += pcoin->GetAvailableCredit(tx_address_amounts);
-                address_amounts.insert(tx_address_amounts.begin(), tx_address_amounts.end());
+                ReduceAddressAmounts(address_amounts, tx_address_amounts);
             }
         }
     }
@@ -2950,7 +2956,7 @@ void CWallet::AvailableCoins(
         }
 
         if (invite) {
-            vCoins.erase(std::remove_if(vCoins.begin(), vCoins.end(), 
+            vCoins.erase(std::remove_if(vCoins.begin(), vCoins.end(),
                         [&address_amounts](const COutput& coin) {
                             const auto& txout = coin.tx->tx->vout[coin.i];
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -99,6 +99,8 @@ enum WalletFeature
     FEATURE_LATEST = FEATURE_BASE // HD is optional, use FEATURE_COMPRPUBKEY as latest version
 };
 
+using AddressAmountMap = std::map<referral::Address, CAmount>;
+
 /** A key pool entry */
 class CKeyPool
 {
@@ -292,6 +294,8 @@ public:
     bool IsCoinBase() const override { return false; }
 };
 
+
+
 } // namespace referral
 
 /**
@@ -373,6 +377,7 @@ public:
     mutable CAmount nImmatureWatchCreditCached;
     mutable CAmount nAvailableWatchCreditCached;
     mutable CAmount nChangeCached;
+    mutable AddressAmountMap available_credit_address_amounts;
 
     CWalletTx(bool invite = false)
     {
@@ -413,6 +418,7 @@ public:
         nCreditCached = 0;
         nImmatureCreditCached = 0;
         nAvailableCreditCached = 0;
+        available_credit_address_amounts.clear();
         nWatchDebitCached = 0;
         nWatchCreditCached = 0;
         nAvailableWatchCreditCached = 0;
@@ -482,6 +488,7 @@ public:
     {
         fCreditCached = false;
         fAvailableCreditCached = false;
+        available_credit_address_amounts.clear();
         fImmatureCreditCached = false;
         fWatchDebitCached = false;
         fWatchCreditCached = false;
@@ -504,7 +511,7 @@ public:
     CAmount GetDebit(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
-    CAmount GetAvailableCredit(bool fUseCache=true) const;
+    CAmount GetAvailableCredit(AddressAmountMap&, bool fUseCache=true) const;
     CAmount GetImmatureWatchOnlyCredit(const bool& fUseCache=true) const;
     CAmount GetAvailableWatchOnlyCredit(const bool& fUseCache=true) const;
     CAmount GetChange() const;


### PR DESCRIPTION
The coin selection algorithm needs to be fixed to handle wallets with many keys. The selection algorithm must not select addresses with 1 remaining invite because doing so will deactivate the address. This is primarily impacting pre-daedalus wallets. But can impact easysend and vaults.

- [x]  Make sure balances are computed by reducing balance by 1 for each unique address in the wallet.
- [x]  Make sure coins are selected with more than 1 invite for an address.
- [x] Test