### PR TITLE
Confirmed status was not set to false on startup.

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -40,12 +40,13 @@
 
 
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
-    QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),
-    transactionTableModel(0),
-    recentRequestsTableModel(0),
-    cachedBalance(0), cachedUnconfirmedBalance(0), cachedImmatureBalance(0),
-    cachedEncryptionStatus(Unencrypted),
-    cachedNumBlocks(0)
+    QObject{parent}, wallet{_wallet}, optionsModel{_optionsModel}, addressTableModel{0},
+    transactionTableModel{0},
+    recentRequestsTableModel{0},
+    cachedBalance{0}, cachedUnconfirmedBalance{0}, cachedImmatureBalance{0},
+    cachedEncryptionStatus{Unencrypted},
+    cachedNumBlocks{0},
+    isConfirmed{false}
 {
     fHaveWatchOnly = wallet->HaveWatchOnly();
     fForceCheckBalanceChanged = false;


### PR DESCRIPTION
This caused it to be false or true, depending on what was in memory.
The mining menu for new users who would be invited may not change to
enabled because of this.