### PR TITLE
Show aliases for transactions.

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -439,14 +439,7 @@ int AddressTableModel::lookupAddress(const QString &address) const
 {
     QModelIndexList lst = match(index(0, Address, QModelIndex()),
                                 Qt::EditRole, address, 1, Qt::MatchExactly);
-    if(lst.isEmpty())
-    {
-        return -1;
-    }
-    else
-    {
-        return lst.at(0).row();
-    }
+    return lst.isEmpty() ? -1 : lst.at(0).row();
 }
 
 void AddressTableModel::emitDataChanged(int idx)

--- a/src/qt/meritgui.cpp
+++ b/src/qt/meritgui.cpp
@@ -1083,16 +1083,26 @@ void MeritGUI::showEvent(QShowEvent *event)
 }
 
 #ifdef ENABLE_WALLET
-void MeritGUI::incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label)
+void MeritGUI::incomingTransaction(
+        const QString& date,
+        int unit,
+        const CAmount& amount,
+        const QString& type,
+        const QString& from,
+        const QString& to,
+        const QString& label)
 {
     // On new transaction, make an info balloon
     QString msg = tr("Date: %1\n").arg(date) +
                 tr("Amount: %1\n").arg(MeritUnits::formatWithUnit(unit, amount, true)) +
                 tr("Type: %1\n").arg(type);
-    if (!label.isEmpty())
+    if (!label.isEmpty()) {
         msg += tr("Label: %1\n").arg(label);
-    else if (!address.isEmpty())
-        msg += tr("Address: %1\n").arg(address);
+    } else if (!from.isEmpty()) {
+        msg += tr("From: %1\nTo: %2\n").arg(from).arg(to);
+    } else  {
+        msg += tr("To: %2\n").arg(to);
+    }
 
     QString title;
     if (type.contains("invite")) {

--- a/src/qt/meritgui.h
+++ b/src/qt/meritgui.h
@@ -209,7 +209,14 @@ public Q_SLOTS:
     bool handlePaymentRequest(const SendCoinsRecipient& recipient);
 
     /** Show incoming transaction notification for new transactions. */
-    void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label);
+    void incomingTransaction(
+            const QString& date,
+            int unit,
+            const CAmount& amount,
+            const QString& type,
+            const QString& address,
+            const QString& alias,
+            const QString& label);
 #endif // ENABLE_WALLET
 
 private Q_SLOTS:

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -53,9 +53,16 @@ public:
         int xpad = 8;
         int ypad = 10;
         int halfheight = (mainRect.height() - 2*ypad)/2;
-        QRect amountRect(mainRect.left() + xpad, mainRect.top()+ypad, mainRect.width() - 2*xpad, halfheight);
-        QRect timestampRect(mainRect.left() + xpad, mainRect.top()+ypad+halfheight, mainRect.width() - xpad, halfheight);
+        QRect topRect(mainRect.left() + xpad, mainRect.top()+ypad, mainRect.width() - 2*xpad, halfheight);
+        QRect bottomRect(mainRect.left() + xpad, mainRect.top()+ypad+halfheight, mainRect.width() - xpad, halfheight);
         QLine line(mainRect.left() + xpad, mainRect.bottom(), mainRect.right() - xpad, mainRect.bottom());
+
+        QString fromString = index.data(TransactionTableModel::FromRole).toString();
+        if(fromString.count(",") > 0) {
+            fromString ="many addresses";
+        }
+
+        QString toString = index.data(TransactionTableModel::ToRole).toString();
 
         QDateTime date = index.data(TransactionTableModel::DateRole).toDateTime();
         qint64 amount = index.data(TransactionTableModel::AmountRole).toLongLong();
@@ -81,7 +88,7 @@ public:
         }
 
         painter->setPen(COLOR_BAREADDRESS);
-        painter->drawText(timestampRect, Qt::AlignLeft|Qt::AlignVCenter, GUIUtil::dateTimeStr(date));
+        painter->drawText(bottomRect, Qt::AlignLeft|Qt::AlignVCenter, GUIUtil::dateTimeStr(date));
 
         QFont font;
         font.setBold(true);
@@ -90,10 +97,11 @@ public:
 
         QString amountText;
 
+        QString label;
         if(amount < 0)
         {
             foreground = COLOR_NEGATIVE;
-            amountText = QString("Sent: ");
+            label = QString("To ") + toString;
             amount = -amount;
         }
         else
@@ -103,14 +111,16 @@ public:
 
             switch(txType) {
                 case TransactionRecord::Generated:
-                    amountText = QString("Mining Reward: ");
+                    label = QString("Mining Reward");
                     break;
                 case TransactionRecord::GeneratedInvite:
-                    amountText = QString("Invite: ");
+                    label = QString("Invite");
                     break;
                 case TransactionRecord::AmbassadorReward:
-                    amountText = QString("Ambassador Reward: ");
+                    label = QString("Ambassador Reward");
                     break;
+                default:
+                    label = QString("From ") + fromString;
             }
         }
 
@@ -121,13 +131,23 @@ public:
             amountText += MeritUnits::formatWithUnit(unit, amount, false, MeritUnits::separatorAlways);
         }
 
+        auto label_rect = painter->boundingRect(topRect, label);
+        auto amount_rect = painter->boundingRect(topRect, amountText);
+        while((topRect.width() < label_rect.width() + amount_rect.width()) && label.length() > 3) {
+            label = label.left(std::max(0, label.length() - 6)) + "...";
+            label_rect = painter->boundingRect(topRect, label);
+        }
+
         painter->setPen(foreground);
-        painter->drawText(amountRect, Qt::AlignLeft|Qt::AlignVCenter, amountText);
+        if(label.length() > 3) {
+            painter->drawText(topRect, Qt::AlignLeft|Qt::AlignVCenter, label);
+        }
+        painter->drawText(topRect, Qt::AlignRight|Qt::AlignVCenter, amountText);
 
         if(!confirmed)
         {
             painter->setPen(COLOR_UNCONFIRMED);
-            painter->drawText(amountRect, Qt::AlignRight|Qt::AlignVCenter, QStringLiteral("(unconfirmed)"));
+            painter->drawText(bottomRect, Qt::AlignRight|Qt::AlignVCenter, QStringLiteral("(unconfirmed)"));
         }
 
         painter->setPen(Qt::lightGray);
@@ -604,7 +624,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         approvedRequestsFilter->setFilterFixedString(QString("Confirmed"));
 
         ui->listTransactions->setModel(txFilter.get());
-        ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
+        ui->listTransactions->setModelColumn(TransactionTableModel::Address);
 
         ui->listPendingRequests->setModel(pendingRequestsFilter.get());
         ui->listApprovedRequests->setModel(approvedRequestsFilter.get());

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -93,21 +93,13 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         if (nNet > 0)
         {
             // Credit
-            CTxDestination address = LookupDestination(rec->address);
-            if (IsValidDestination(address)) {
-                if (wallet->mapAddressBook.count(address))
-                {
-                    strHTML += "<b>" + tr("From") + ":</b> " + tr("unknown") + "<br>";
-                    strHTML += "<b>" + tr("To") + ":</b> ";
-                    strHTML += GUIUtil::HtmlEscape(rec->address);
-                    QString addressOwned = (::IsMine(*wallet, address) == ISMINE_SPENDABLE) ? tr("own address") : tr("watch-only");
-                    if (!wallet->mapAddressBook[address].name.empty())
-                        strHTML += " (" + addressOwned + ", " + tr("label") + ": " + GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + ")";
-                    else
-                        strHTML += " (" + addressOwned + ")";
-                    strHTML += "<br>";
-                }
-            }
+            strHTML += "<b>" + tr("From") + ":</b> " + QString::fromStdString(rec->from) + "<br>";
+            strHTML += "<b>" + tr("To") + ":</b> ";
+            strHTML += GUIUtil::HtmlEscape(rec->to);
+            auto dest = LookupDestination(rec->to);
+            if (!wallet->mapAddressBook[dest].name.empty())
+                strHTML += QString{"("} + GUIUtil::HtmlEscape(wallet->mapAddressBook[dest].name) + QString{")"};
+            strHTML += "<br>";
         }
     }
 
@@ -119,7 +111,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         // Online transaction
         std::string strAddress = wtx.mapValue["to"];
         strHTML += "<b>" + tr("To") + ":</b> ";
-        CTxDestination dest = DecodeDestination(strAddress);
+        CTxDestination dest = LookupDestination(strAddress);
         if (wallet->mapAddressBook.count(dest) && !wallet->mapAddressBook[dest].name.empty())
             strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[dest].name) + " ";
         strHTML += GUIUtil::HtmlEscape(strAddress) + "<br>";

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -18,15 +18,15 @@ const QDateTime TransactionFilterProxy::MIN_DATE = QDateTime::fromTime_t(0);
 const QDateTime TransactionFilterProxy::MAX_DATE = QDateTime::fromTime_t(0xFFFFFFFF);
 
 TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :
-    QSortFilterProxyModel(parent),
-    dateFrom(MIN_DATE),
-    dateTo(MAX_DATE),
-    addrPrefix(),
-    typeFilter(ALL_TYPES),
-    watchOnlyFilter(WatchOnlyFilter_All),
-    minAmount(0),
-    limitRows(-1),
-    showInactive(true)
+    QSortFilterProxyModel{parent},
+    dateFrom{MIN_DATE},
+    dateTo{MAX_DATE},
+    prefix{},
+    typeFilter{ALL_TYPES},
+    watchOnlyFilter{WatchOnlyFilter_All},
+    minAmount{0},
+    limitRows{-1},
+    showInactive{true}
 {
 }
 
@@ -37,7 +37,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     int type = index.data(TransactionTableModel::TypeRole).toInt();
     QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
     bool involvesWatchAddress = index.data(TransactionTableModel::WatchonlyRole).toBool();
-    QString address = index.data(TransactionTableModel::AddressRole).toString();
+    QString from = index.data(TransactionTableModel::FromRole).toString();
+    QString to = index.data(TransactionTableModel::ToRole).toString();
     QString label = index.data(TransactionTableModel::LabelRole).toString();
     qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
     int status = index.data(TransactionTableModel::StatusRole).toInt();
@@ -52,8 +53,13 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
     if(datetime < dateFrom || datetime > dateTo)
         return false;
-    if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
+
+    if (!from.contains(prefix, Qt::CaseInsensitive) 
+            && !label.contains(prefix, Qt::CaseInsensitive)
+            && !to.contains(prefix, Qt::CaseInsensitive)) {
         return false;
+    }
+
     if(amount < minAmount)
         return false;
 
@@ -67,9 +73,9 @@ void TransactionFilterProxy::setDateRange(const QDateTime &from, const QDateTime
     invalidateFilter();
 }
 
-void TransactionFilterProxy::setAddressPrefix(const QString &_addrPrefix)
+void TransactionFilterProxy::setPrefix(const QString &p)
 {
-    this->addrPrefix = _addrPrefix;
+    this->prefix = p;
     invalidateFilter();
 }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -36,7 +36,8 @@ public:
     };
 
     void setDateRange(const QDateTime &from, const QDateTime &to);
-    void setAddressPrefix(const QString &addrPrefix);
+    void setPrefix(const QString&);
+
     /**
       @note Type filter takes a bit field created with TYPE() or ALL_TYPES
      */
@@ -58,7 +59,7 @@ protected:
 private:
     QDateTime dateFrom;
     QDateTime dateTo;
-    QString addrPrefix;
+    QString prefix;
     quint32 typeFilter;
     WatchOnlyFilter watchOnlyFilter;
     CAmount minAmount;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -80,6 +80,7 @@ public:
         SendToAddress,
         SendToOther,
         RecvWithAddress,
+        RecvFromAddress,
         RecvFromOther,
         SendToSelf,
         GeneratedInvite,
@@ -91,23 +92,41 @@ public:
     static const int RecommendedNumConfirmations = 6;
 
     TransactionRecord():
-            hash(), time(0), type(Other), address(""), debit(0), credit(0), idx(0)
-    {
-    }
+        hash{},
+        time{0},
+        type{Other},
+        from{""},
+        to{""},
+        debit{0},
+        credit{0},
+        idx{0} {}
 
     TransactionRecord(uint256 _hash, qint64 _time):
-            hash(_hash), time(_time), type(Other), address(""), debit(0),
-            credit(0), idx(0)
-    {
-    }
+            hash(_hash),
+            time(_time),
+            type(Other),
+            from(""),
+            to(""),
+            debit(0),
+            credit(0),
+            idx(0) {}
 
-    TransactionRecord(uint256 _hash, qint64 _time,
-                Type _type, const std::string &_address,
-                const CAmount& _debit, const CAmount& _credit):
-            hash(_hash), time(_time), type(_type), address(_address), debit(_debit), credit(_credit),
-            idx(0)
-    {
-    }
+    TransactionRecord(
+            uint256 _hash,
+            qint64 _time,
+                Type _type,
+                const std::string &_from,
+                const std::string &_to,
+                const CAmount& _debit,
+                const CAmount& _credit):
+            hash{_hash},
+            time{_time},
+            type{_type},
+            from{_from},
+            to{_to},
+            debit{_debit},
+            credit{_credit},
+            idx{0} {}
 
     /** Decompose CWallet transaction to model transaction records.
      */
@@ -119,7 +138,8 @@ public:
     uint256 hash;
     qint64 time;
     Type type;
-    std::string address;
+    std::string from;
+    std::string to;
     CAmount debit;
     CAmount credit;
     /**@}*/

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -247,7 +247,7 @@ TransactionTableModel::TransactionTableModel(const PlatformStyle *_platformStyle
         fProcessingQueuedTransactions(false),
         platformStyle(_platformStyle)
 {
-    columns << QString() << QString() << tr("Date") << tr("Type") << tr("Label") << MeritUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit()) << tr("Invites");
+    columns << QString() << QString() << tr("Date") << tr("Type") << tr("Address") << MeritUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit()) << tr("Invites");
     priv->refreshWallet();
 
     connect(walletModel->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
@@ -283,7 +283,7 @@ void TransactionTableModel::updateConfirmations()
     //  for all rows. Qt is smart enough to only actually request the data for the
     //  visible rows.
     Q_EMIT dataChanged(index(0, Status), index(priv->size()-1, Status));
-    Q_EMIT dataChanged(index(0, ToAddress), index(priv->size()-1, ToAddress));
+    Q_EMIT dataChanged(index(0, Address), index(priv->size()-1, Address));
 }
 
 int TransactionTableModel::rowCount(const QModelIndex &parent) const
@@ -354,18 +354,20 @@ QString TransactionTableModel::formatTxDate(const TransactionRecord *wtx) const
 /* Look up address in address book, if found return label (address)
    otherwise just return (address)
  */
-QString TransactionTableModel::lookupAddress(const std::string &address, bool tooltip) const
+QString TransactionTableModel::lookupAddress(
+        const std::string &address,
+        bool tooltip) const
 {
     QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(address));
     QString description;
-    if(!label.isEmpty())
-    {
+    if (!label.isEmpty()) {
         description += label;
+    } else if (tooltip && !address.empty()) {
+        description += QString{"("} + QString::fromStdString(address) + ")";
+    } else if (!address.empty()) {
+        description += QString::fromStdString(address);
     }
-    if(label.isEmpty() || tooltip)
-    {
-        description += QString(" (") + QString::fromStdString(address) + QString(")");
-    }
+
     return description;
 }
 
@@ -375,6 +377,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
     {
     case TransactionRecord::RecvWithAddress:
         return tr("Received with");
+    case TransactionRecord::RecvFromAddress:
+        return tr("Received fom");
     case TransactionRecord::RecvFromOther:
         return tr("Received from");
     case TransactionRecord::SendToAddress:
@@ -406,6 +410,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     case TransactionRecord::GeneratedInvite:
         return QIcon(":/icons/tx_mined");
     case TransactionRecord::RecvWithAddress:
+    case TransactionRecord::RecvFromAddress:
     case TransactionRecord::RecvFromOther:
     case TransactionRecord::RecvInvite:
         return QIcon(":/icons/tx_input");
@@ -418,7 +423,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
     }
 }
 
-QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, bool tooltip) const
+QString TransactionTableModel::formatTxAddress(const TransactionRecord *wtx, bool tooltip) const
 {
     QString watchAddress;
     if (tooltip) {
@@ -430,16 +435,18 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     {
     case TransactionRecord::RecvFromOther:
     case TransactionRecord::RecvInvite:
-        return QString::fromStdString(wtx->address) + watchAddress;
+        return lookupAddress(wtx->from, tooltip) + watchAddress;
+    case TransactionRecord::RecvFromAddress:
+        return lookupAddress(wtx->from, tooltip) + watchAddress;
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::AmbassadorReward:
     case TransactionRecord::Generated:
     case TransactionRecord::GeneratedInvite:
     case TransactionRecord::SendInvite:
-        return lookupAddress(wtx->address, tooltip) + watchAddress;
+        return lookupAddress(wtx->to, tooltip) + watchAddress;
     case TransactionRecord::SendToOther:
-        return QString::fromStdString(wtx->address) + watchAddress;
+        return QString::fromStdString(wtx->to) + watchAddress;
     case TransactionRecord::SendToSelf:
     default:
         return tr("(n/a)") + watchAddress;
@@ -452,6 +459,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     switch(wtx->type)
     {
     case TransactionRecord::RecvWithAddress:
+    case TransactionRecord::RecvFromAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::AmbassadorReward:
     case TransactionRecord::Generated:
@@ -459,8 +467,8 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::SendInvite:
     case TransactionRecord::RecvInvite:
         {
-        QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->address));
-        if(label.isEmpty())
+        QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->from));
+        if(label.isEmpty() && !wtx->from.empty())
             return COLOR_BAREADDRESS;
         } break;
     case TransactionRecord::SendToSelf:
@@ -547,11 +555,16 @@ QVariant TransactionTableModel::txWatchonlyDecoration(const TransactionRecord *w
 QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
 {
     QString tooltip = formatTxStatus(rec) + QString("\n") + formatTxType(rec);
-    if(rec->type == TransactionRecord::RecvFromOther || rec->type == TransactionRecord::SendToOther ||
-       rec->type == TransactionRecord::SendToAddress || rec->type == TransactionRecord::RecvWithAddress ||
-       rec->type == TransactionRecord::SendInvite || rec->type == TransactionRecord::RecvInvite)
-    {
-        tooltip += QString(" ") + formatTxToAddress(rec, true);
+    switch(rec->type) {
+        case TransactionRecord::RecvInvite:
+        case TransactionRecord::RecvFromAddress:
+        case TransactionRecord::SendToOther:
+        case TransactionRecord::SendToAddress:
+        case TransactionRecord::RecvWithAddress:
+        case TransactionRecord::RecvFromOther:
+        case TransactionRecord::SendInvite:
+            tooltip += QString(" ") + formatTxAddress(rec, true);
+            break;
     }
     return tooltip;
 }
@@ -571,7 +584,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
             return txStatusDecoration(rec);
         case Watchonly:
             return txWatchonlyDecoration(rec);
-        case ToAddress:
+        case Address:
             return txAddressDecoration(rec);
         }
         break;
@@ -587,8 +600,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
             return formatTxDate(rec);
         case Type:
             return formatTxType(rec);
-        case ToAddress:
-            return formatTxToAddress(rec, false);
+        case Address:
+            return formatTxAddress(rec, false);
         case Amount:
             return !rec->IsInvite() ? formatTxAmount(rec, true, MeritUnits::separatorAlways) : QString("");
         case Invite:
@@ -607,8 +620,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
             return formatTxType(rec);
         case Watchonly:
             return (rec->involvesWatchAddress ? 1 : 0);
-        case ToAddress:
-            return formatTxToAddress(rec, true);
+        case Address:
+            return formatTxAddress(rec, false);
         case Amount:
             return qint64(rec->credit + rec->debit);
         case Invite:
@@ -634,7 +647,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         {
             return COLOR_NEGATIVE;
         }
-        if(index.column() == ToAddress)
+        if(index.column() == Address)
         {
             return addressColor(rec);
         }
@@ -649,10 +662,27 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return txWatchonlyDecoration(rec);
     case LongDescriptionRole:
         return priv->describe(rec, walletModel->getOptionsModel()->getDisplayUnit());
-    case AddressRole:
-        return QString::fromStdString(rec->address);
+    case FromRole:
+        return QString::fromStdString(rec->from);
+    case ToRole:
+        return QString::fromStdString(rec->to);
     case LabelRole:
-        return walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->address));
+        {
+            //TODO Add support for labelling transactions using the transaction id + ouput index.
+            QString label;
+            if (rec->from.empty()) {
+                auto address_label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->to));
+                label = address_label.isEmpty() ?  QString::fromStdString(rec->to) : address_label;
+            } else {
+                auto from_label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->from));
+                auto to_label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->to));
+
+                label += from_label.isEmpty() ? QString::fromStdString(rec->from) : from_label;
+                label += " to ";
+                label += to_label.isEmpty() ? QString::fromStdString(rec->to) : to_label;
+            }
+            return label;
+        }
     case AmountRole:
         return qint64(rec->credit + rec->debit);
     case IsInviteRole:
@@ -669,7 +699,7 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         {
             QString details;
             QDateTime date = QDateTime::fromTime_t(static_cast<uint>(rec->time));
-            QString txLabel = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(rec->address));
+            QString txLabel = data(index, RoleIndex::LabelRole).toString();
 
             details.append(date.toString("M/d/yy HH:mm"));
             details.append(" ");
@@ -679,16 +709,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
                 details.append(formatTxType(rec));
                 details.append(" ");
             }
-            if(!rec->address.empty()) {
-                if(txLabel.isEmpty())
-                    details.append(tr("(no label)") + " ");
-                else {
-                    details.append("(");
-                    details.append(txLabel);
-                    details.append(") ");
-                }
-                details.append(QString::fromStdString(rec->address));
-                details.append(" ");
+            if(!rec->to.empty()) {
+                details.append(txLabel);
             }
             details.append(formatTxAmount(rec, false, MeritUnits::separatorNever));
             return details;
@@ -728,8 +750,8 @@ QVariant TransactionTableModel::headerData(int section, Qt::Orientation orientat
                 return tr("Type of transaction.");
             case Watchonly:
                 return tr("Whether or not a watch-only address is involved in this transaction.");
-            case ToAddress:
-                return tr("User-defined intent/purpose of the transaction.");
+            case Address:
+                return tr("Which address(es) did the transaction go to or from?");
             case Amount:
                 return tr("Amount removed from or added to balance.");
             case Invite:

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -33,7 +33,7 @@ public:
         Watchonly = 1,
         Date = 2,
         Type = 3,
-        ToAddress = 4,
+        Address = 4,
         Amount = 5,
         Invite = 6,
     };
@@ -53,7 +53,9 @@ public:
         /** Long description (HTML format) */
         LongDescriptionRole,
         /** Address of transaction */
-        AddressRole,
+        FromRole,
+        /** Alias of transaction */
+        ToRole,
         /** Label of address related to transaction */
         LabelRole,
         /** Net amount of transaction */
@@ -98,13 +100,19 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
 
-    QString lookupAddress(const std::string &address, bool tooltip) const;
+    QString lookupAddress(const std::string& address, bool tooltip) const;
+
     QVariant addressColor(const TransactionRecord *wtx) const;
     QString formatTxStatus(const TransactionRecord *wtx) const;
     QString formatTxDate(const TransactionRecord *wtx) const;
     QString formatTxType(const TransactionRecord *wtx) const;
-    QString formatTxToAddress(const TransactionRecord *wtx, bool tooltip) const;
-    QString formatTxAmount(const TransactionRecord *wtx, bool showUnconfirmed = true, MeritUnits::SeparatorStyle separators=MeritUnits::separatorStandard) const;
+    QString formatTxAddress(const TransactionRecord *wtx, bool tooltip) const;
+
+    QString formatTxAmount(
+            const TransactionRecord *wtx,
+            bool showUnconfirmed = true,
+            MeritUnits::SeparatorStyle separators=MeritUnits::separatorStandard) const;
+
     QString formatTooltip(const TransactionRecord *rec) const;
     QString formatInvite(const TransactionRecord *rec, bool showUnconfirmed = true) const;
     QVariant txStatusDecoration(const TransactionRecord *wtx) const;

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -78,6 +78,7 @@ private:
     QDateTimeEdit *dateTo;
     QAction *abandonAction;
     QAction *bumpFeeAction;
+    QAction *editFromLabelAction;
 
     QWidget *createDateRangeWidget();
 
@@ -91,13 +92,16 @@ private Q_SLOTS:
     void contextualMenu(const QPoint &);
     void dateRangeChanged();
     void showDetails();
-    void copyAddress();
-    void editLabel();
+    void copyFrom();
+    void copyTo();
     void copyLabel();
     void copyAmount();
     void copyTxID();
     void copyTxHex();
     void copyTxPlainText();
+    void editFromLabel();
+    void editToLabel();
+    void editLabel(const QString& address);
     void openThirdPartyTxUrl(QString url);
     void updateWatchOnlyColumn(bool fHaveWatchOnly);
     void abandonTx();

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -96,7 +96,9 @@ void WalletView::setMeritGUI(MeritGUI *gui)
         connect(this, SIGNAL(encryptionStatusChanged(int)), gui, SLOT(setEncryptionStatus(int)));
 
         // Pass through transaction notifications
-        connect(this, SIGNAL(incomingTransaction(QString,int,CAmount,QString,QString,QString)), gui, SLOT(incomingTransaction(QString,int,CAmount,QString,QString,QString)));
+        connect(
+                this, SIGNAL(incomingTransaction(QString,int,CAmount,QString,QString,QString,QString)),
+                gui, SLOT(incomingTransaction(QString,int,CAmount,QString,QString,QString,QString)));
 
         // Connect HD enabled state signal
         connect(this, SIGNAL(hdEnabledStatusChanged(int)), gui, SLOT(setHDStatus(int)));
@@ -165,10 +167,18 @@ void WalletView::processNewTransaction(const QModelIndex& parent, int start, int
     qint64 amount = ttm->index(start, TransactionTableModel::Amount, parent).data(Qt::EditRole).toULongLong();
     QString type = ttm->index(start, TransactionTableModel::Type, parent).data().toString();
     QModelIndex index = ttm->index(start, 0, parent);
-    QString address = ttm->data(index, TransactionTableModel::AddressRole).toString();
+    QString from = ttm->data(index, TransactionTableModel::FromRole).toString();
+    QString to = ttm->data(index, TransactionTableModel::ToRole).toString();
     QString label = ttm->data(index, TransactionTableModel::LabelRole).toString();
 
-    Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address, label);
+    Q_EMIT incomingTransaction(
+            date,
+            walletModel->getOptionsModel()->getDisplayUnit(),
+            amount,
+            type,
+            from,
+            to,
+            label);
 }
 
 void WalletView::gotoOverviewPage()

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -124,7 +124,15 @@ Q_SIGNALS:
     /** HD-Enabled status of wallet changed (only possible during startup) */
     void hdEnabledStatusChanged(int hdEnabled);
     /** Notify that a new transaction appeared */
-    void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address, const QString& label);
+    void incomingTransaction(
+            const QString& date,
+            int unit,
+            const CAmount& amount,
+            const QString& type,
+            const QString& address,
+            const QString& alias,
+            const QString& label);
+
     /** Notify that the out of sync warning icon has been pressed */
     void outOfSyncWarningClicked();
 };

--- a/src/referrals.h
+++ b/src/referrals.h
@@ -80,8 +80,14 @@ public:
     /** Get referral by address */
     MaybeReferral GetReferral(const Address&) const;
 
+    /** Get referral by hash */
+    MaybeReferral GetReferral(const uint256&) const;
+
     /** Get referral by alias */
     MaybeReferral GetReferral(const std::string& alias, bool normalize_alias) const;
+
+    /** Get referral by address */
+    MaybeReferral GetReferral(const ReferralId&, bool normalize_alias) const;
 
     /** Check if referral exists by beaconed address */
     bool Exists(const Address&) const;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5326,15 +5326,20 @@ referral::ReferralRef LookupReferral(
         referral::ReferralId& referral_id,
         bool normalize_alias)
 {
-    //We don't do transpose check here because LookupReferral is used by client
-    //code retrieval not consensus.
-    auto chain_referral = prefviewdb->GetReferral(referral_id, normalize_alias);
+    auto chain_referral = prefviewcache->GetReferral(referral_id, normalize_alias);
 
     if (chain_referral) {
         return MakeReferralRef(*chain_referral);
     }
 
     return mempoolReferral.Get(referral_id);
+}
+
+std::string FindAliasForAddress(const uint160 &address)
+{
+    referral::ReferralId id = address;
+    auto ref = LookupReferral(id, true);
+    return ref ? ref->GetAlias() : "";
 }
 
 bool IsWitnessCommitment(const CTxOut& out)

--- a/src/validation.h
+++ b/src/validation.h
@@ -604,6 +604,11 @@ referral::ReferralRef LookupReferral(
         referral::ReferralId& referral_id,
         bool normalize_alias);
 
+/**
+ * Returns an alias for a particular address. Otherwise an empty string.
+ */
+std::string FindAliasForAddress(const uint160 &hash);
+
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex(const CChainParams& params);
 


### PR DESCRIPTION
- It figures out who sent you the transaction by looking up the previous transaction.
- Displays aliases if they are available, otherwise the address.
- Better Recent Transactions view with fancier rendering and showing aliases/addresses

![transaliases](https://user-images.githubusercontent.com/3760639/38756337-059aaf3c-3f1e-11e8-8c7d-4f458102c642.png)

![recentrans](https://user-images.githubusercontent.com/3760639/38756240-af9365b6-3f1d-11e8-9677-bd2bb4ebc8df.png)
