### PR TITLE
Better Invite Distribution

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -132,6 +132,7 @@ MERIT_CORE_H = \
   pog/anv.h \
   pog/select.h \
   pog/wrs.h \
+  pog/invitebuffer.h \
   pog/reward.h \
   protocol.h \
   random.h \
@@ -226,6 +227,7 @@ libmerit_server_a_SOURCES = \
   pog/reward.cpp \
   pog/select.cpp \
   pog/wrs.cpp \
+  pog/invitebuffer.cpp \
   policy/fees.cpp \
   policy/policy.cpp \
   policy/rbf.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -318,7 +318,7 @@ public:
         consensus.safer_alias_blockheight = 2060;
 
         // Block where improved invites turn on
-        consensus.imp_invites_blockheight = 82161;
+        consensus.imp_invites_blockheight = 82275;
         consensus.imp_block_window = 4;
         consensus.imp_min_one_invite_for_every_x_blocks = 2; //invite every minute
         consensus.imp_miner_reward_for_every_x_blocks = 10; //invite every 10 minutes at a minumum, 144 per day.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -173,7 +173,8 @@ public:
 
         // Block where improved invites turn on
         consensus.imp_invites_blockheight = 179096;
-        consensus.imp_block_window = 60 * 24 * 2; //2 days of blocks
+        consensus.imp_block_window = 60 * 24 * 1; //1 days of blocks
+        consensus.imp_min_one_invite_for_every_x_blocks = 3; //invite every 3 minutes at a minumum, 480 per day.
         consensus.imp_weights = {60, 40}; 
 
         /**
@@ -316,7 +317,7 @@ public:
         consensus.safer_alias_blockheight = 2060;
 
         // Block where improved invites turn on
-        consensus.imp_invites_blockheight = 80278;
+        consensus.imp_invites_blockheight = 82000;
         consensus.imp_block_window = 4;
         consensus.imp_weights = {60, 40}; 
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -171,6 +171,10 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x0000000000000000003b9ce759c2a087d52abc4266f8f4ebd6d768b89defa50a"); //477890
 
+        // Block where improved invites turn on
+        consensus.imp_invites_blockheight = 179096;
+        consensus.imp_block_window = 60 * 24 * 2; //2 days of blocks
+        consensus.imp_weights = {60, 40}; 
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -311,6 +315,11 @@ public:
         // Block where safer aliases are enabled.
         consensus.safer_alias_blockheight = 2060;
 
+        // Block where improved invites turn on
+        consensus.imp_invites_blockheight = 80278;
+        consensus.imp_block_window = 4;
+        consensus.imp_weights = {60, 40}; 
+
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -322,7 +331,6 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = AddressPrefix(1, 110);
         base58Prefixes[SCRIPT_ADDRESS] = AddressPrefix(1, 125);
         base58Prefixes[PARAM_SCRIPT_ADDRESS] = AddressPrefix(1, 117);
-        //base58Prefixes[SECRET_KEY] = AddressPrefix(1, 239);
         base58Prefixes[SECRET_KEY] = AddressPrefix(1, 128);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
@@ -419,8 +427,7 @@ public:
         consensus.daedalus_max_outstanding_invites_per_address = 3;
 
         consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].bit = 27;
-        consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].start_block = 500;
-        consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].end_block = 5000;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].start_block = 10;
         consensus.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].end_block = std::numeric_limits<int>::max();
 
         // The best chain should have at least this much work.
@@ -430,7 +437,12 @@ public:
         consensus.defaultAssumeValid = uint256S("0x00");
 
         // Block where safer aliases are enabled.
-        consensus.safer_alias_blockheight = 2060;
+        consensus.safer_alias_blockheight = 20;
+
+        // Block where improved invites turn on
+        consensus.imp_invites_blockheight = 30;
+        consensus.imp_block_window = 4;
+        consensus.imp_weights = {60, 40}; 
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -172,7 +172,7 @@ public:
         consensus.defaultAssumeValid = uint256S("0x0000000000000000003b9ce759c2a087d52abc4266f8f4ebd6d768b89defa50a"); //477890
 
         // Block where improved invites turn on
-        consensus.imp_invites_blockheight = 180640; //Fri, Jan 4th
+        consensus.imp_invites_blockheight = 180980; //Sat, Jan 5th 6:11:00 ish GMT
         consensus.imp_block_window = 60 * 24 * 1; //1 days of blocks
         consensus.imp_min_one_invite_for_every_x_blocks = 10; //invite every 10 minutes at a minumum, 144 per day.
         consensus.imp_miner_reward_for_every_x_blocks = 10; //invite every 10 minutes at a minumum, 144 per day.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -172,9 +172,10 @@ public:
         consensus.defaultAssumeValid = uint256S("0x0000000000000000003b9ce759c2a087d52abc4266f8f4ebd6d768b89defa50a"); //477890
 
         // Block where improved invites turn on
-        consensus.imp_invites_blockheight = 179096;
+        consensus.imp_invites_blockheight = 180640; //Fri, Jan 4th
         consensus.imp_block_window = 60 * 24 * 1; //1 days of blocks
-        consensus.imp_min_one_invite_for_every_x_blocks = 3; //invite every 3 minutes at a minumum, 480 per day.
+        consensus.imp_min_one_invite_for_every_x_blocks = 10; //invite every 10 minutes at a minumum, 144 per day.
+        consensus.imp_miner_reward_for_every_x_blocks = 10; //invite every 10 minutes at a minumum, 144 per day.
         consensus.imp_weights = {60, 40}; 
 
         /**
@@ -317,8 +318,10 @@ public:
         consensus.safer_alias_blockheight = 2060;
 
         // Block where improved invites turn on
-        consensus.imp_invites_blockheight = 82000;
+        consensus.imp_invites_blockheight = 82161;
         consensus.imp_block_window = 4;
+        consensus.imp_min_one_invite_for_every_x_blocks = 2; //invite every minute
+        consensus.imp_miner_reward_for_every_x_blocks = 10; //invite every 10 minutes at a minumum, 144 per day.
         consensus.imp_weights = {60, 40}; 
 
         pchMessageStart[0] = 0x0b;
@@ -405,9 +408,9 @@ public:
         consensus.powLimit = Consensus::PoWLimit{
             uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
             *consensus.sEdgeBitsAllowed.begin()};
-        consensus.nPowTargetTimespan = 24 * 60 * 60; // one day for nBits adjustment
+        consensus.nPowTargetTimespan = 60; // one minute for nBits adjustment
         consensus.nEdgeBitsTargetThreshold = 2;      // adjust nEdgeBits if block time is twice more/less than expected
-        consensus.nPowTargetSpacing = 1 * 60;        // one minute for a block
+        consensus.nPowTargetSpacing = 10;        // 10 seconds per block
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
@@ -441,8 +444,10 @@ public:
         consensus.safer_alias_blockheight = 20;
 
         // Block where improved invites turn on
-        consensus.imp_invites_blockheight = 30;
+        consensus.imp_invites_blockheight = 12;
         consensus.imp_block_window = 4;
+        consensus.imp_min_one_invite_for_every_x_blocks = 1; //invite every minute
+        consensus.imp_miner_reward_for_every_x_blocks = 10; //invite every 10 minutes at a minumum, 144 per day.
         consensus.imp_weights = {60, 40}; 
 
         pchMessageStart[0] = 0xfa;
@@ -478,9 +483,14 @@ public:
     {
         CAmount genesisReward = 20000000_merit;
 
-        PubKeys genesisKeys = {
-            CPubKey{ParseHex("03C710FD3FD8B56537BF121870AF462107D3583F7E0CBD97F80EE271F48DAFF593")},
-            CPubKey{ParseHex("024F1BC2E023ED1BACDC8171798113F1F7280C881919A11B592A25A976ABFB8798")},
+        // genesis ref address:
+        // sPm5Tq6pZwDtcgGMJcqsvtmh5wZsSqVyRH
+        consensus.genesis_address = uint160{ParseHex("3c759153e6519361689f43d1ed981c1417c05dcf")};
+
+
+        PubKeys genesisKeys{
+            CPubKey(ParseHex("03C710FD3FD8B56537BF121870AF462107D3583F7E0CBD97F80EE271F48DAFF593")),
+                CPubKey(ParseHex("024F1BC2E023ED1BACDC8171798113F1F7280C881919A11B592A25A976ABFB8798")),
         };
 
         const std::string referralSig =
@@ -488,19 +498,21 @@ public:
             "bd1e4ec39902202d4b5ac449d94b49b308f7faf42a2f624b3cc4f1569b7621e9"
             "f967f5b6895626";
 
-        // genesis ref address:
-        // sPm5Tq6pZwDtcgGMJcqsvtmh5wZsSqVyRH
-        consensus.genesis_address = uint160{ParseHex("3c759153e6519361689f43d1ed981c1417c05dcf")};
-
-        genesis = CreateGenesisBlock(genesisKeys, referralSig, TIMESTAMP_MESSAGE, 1514332800,  0, 0x207fffff, 24, 1, genesisReward, consensus);
+        genesis = CreateGenesisBlock(genesisKeys, referralSig, TIMESTAMP_MESSAGE, 1514332800, 381, 0x207fffff, 24, 1, genesisReward, consensus);
 
         genesis.sCycle = {
-            0x15b8f, 0x195867, 0x1bbe29, 0x1bd48c, 0x230a7e, 0x2553db, 0x2c5bd0, 0x31996b, 0x3789b6, 0x48b67a, 0x4a31e0, 0x52a1bf, 0x5f6ddc, 0x60f02d, 0x6de4ec, 0x7e7534, 0x89b733, 0x8ed16d, 0x93ee9f, 0x9d09d8, 0xa19b42, 0xa2374b, 0xa3a53e, 0xab68ff, 0xb3f004, 0xb64ebf, 0xc582b5, 0xcb1628, 0xcc9d57, 0xd0a370, 0xd12874, 0xd14c44, 0xd379b3, 0xd479ec, 0xd62a58, 0xdebb7a, 0xe86442, 0xeb5482, 0xf2609d, 0xf28706, 0xf5e069, 0xf9eb5f
+            0x13529, 0xb3ef1, 0xf3211, 0x166f1d, 0x1fe182, 0x229740, 0x2704c2, 0x2a3b1b,
+            0x32053c, 0x39fee1, 0x3ed8ff, 0x3f079d, 0x408b98, 0x40b31d, 0x434ea2, 0x463eaa,
+            0x482bb4, 0x49eae3, 0x4bb609, 0x545752, 0x5a2d5b, 0x5e3999, 0x6ca1d2, 0x76c4f7,
+            0x826245, 0x82d44d, 0xad2cd4, 0xafd7be, 0xb5792b, 0xb593a2, 0xb7f4fb, 0xc2a540,
+            0xcec41e, 0xd33967, 0xdbb0b8, 0xdc9ce4, 0xdf509e, 0xe04520, 0xe187ef, 0xe30157,
+            0xed068f, 0xfd58fe
         };
 
         consensus.hashGenesisBlock = genesis.GetHash();
-        assert(consensus.hashGenesisBlock == uint256S("795bc3e58f7863d41411eed4f7ec488570250a4907083df553285b7497e6338e"));
-        assert(genesis.hashMerkleRoot == uint256S("b27e04cc1c480dc707e72dd37ffabf0cc12d34c2a535368434350d1de7b5f065"));
+
+        assert(consensus.hashGenesisBlock == uint256S("448f31e47f5daabfd1984f03a64723c7f50b2306961e6f0e7f482e0b49f2dbea"));
+        assert(genesis.hashMerkleRoot == uint256S("8be99a68b2514e86f17368e9cce63d302aa0f29ed91654b7c90dc9f7201fb69f"));
     }
 };
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -95,6 +95,7 @@ struct Params {
     /** Improved Invites */
     int imp_invites_blockheight;
     int imp_block_window;
+    int imp_min_one_invite_for_every_x_blocks;
     std::vector<double> imp_weights;
 
 };

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -18,6 +18,7 @@ enum DeploymentPos
 {
     DEPLOYMENT_GENESIS,
     DEPLOYMENT_DAEDALUS,
+    DEPLOYMENT_IMP_INVITES,
     MAX_VERSION_BITS_DEPLOYMENTS
 };
 
@@ -90,6 +91,11 @@ struct Params {
     
     /** Bug Fix heights */
     int safer_alias_blockheight;
+
+    /** Improved Invites */
+    int imp_invites_blockheight;
+    int imp_block_window;
+    std::vector<double> imp_weights;
 
 };
 } // namespace Consensus

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -96,6 +96,7 @@ struct Params {
     int imp_invites_blockheight;
     int imp_block_window;
     int imp_min_one_invite_for_every_x_blocks;
+    int imp_miner_reward_for_every_x_blocks;
     std::vector<double> imp_weights;
 
 };

--- a/src/pog/invitebuffer.cpp
+++ b/src/pog/invitebuffer.cpp
@@ -59,7 +59,7 @@ namespace pog
 
         InviteStats s;
 
-        auto adjusted_height = AdjustedHeight(height, params);
+        const auto adjusted_height = AdjustedHeight(height, params);
 
         //get cached value, otherwise we compute.
         if(get(adjusted_height, s)) {
@@ -83,6 +83,35 @@ namespace pog
         s.is_set = true;
         insert(adjusted_height, s);
         return s;
+    }
+
+    bool InviteBuffer::set_mean(int height, const MeanStats& mean_stats, const Consensus::Params& params)
+    {
+        LOCK(cs);
+        const auto adjusted_height = AdjustedHeight(height, params);
+
+        if(stats.size() <= adjusted_height) {
+            return false;
+        }
+
+        auto& stat = stats[adjusted_height];
+        stat.mean_stats = mean_stats;
+        stat.mean_set = true;
+
+        return true;
+    }
+
+    bool InviteBuffer::drop(int height, const Consensus::Params& params)
+    {
+        LOCK(cs);
+        const auto adjusted_height = AdjustedHeight(height, params);
+
+        if(stats.size() <= adjusted_height) {
+            return false;
+        }
+
+        stats.resize(adjusted_height);
+        return true;
     }
 
     bool InviteBuffer::get(int adjusted_height, InviteStats& s) const

--- a/src/pog/invitebuffer.cpp
+++ b/src/pog/invitebuffer.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2018 The Merit Foundation developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "pog/invitebuffer.h"
+#include "validation.h"
+
+#include <vector>
+
+namespace pog 
+{
+    InviteBuffer::InviteBuffer(const CChain& c) : chain{c} {}
+
+    bool ComputeStats(
+            const CBlock& block,
+            InviteStats& stats,
+            const Consensus::Params& params)
+    {
+        for (const auto& invite : block.invites) {
+            if (!invite->IsCoinBase()) {
+                for (const auto& in : invite->vin) {
+                    CTransactionRef prev;
+                    uint256 block_inv_is_in;
+
+                    if (!GetTransaction(
+                                in.prevout.hash,
+                                prev,
+                                params,
+                                block_inv_is_in,
+                                false)) {
+                        return false;
+                    }
+
+                    assert(prev);
+                    if (!prev->IsCoinBase()) {
+                        continue;
+                    }
+                    stats.invites_used += prev->vout.at(in.prevout.n).nValue;
+                }
+            } else {
+                for (const auto& out : invite->vout) {
+                    stats.invites_created += out.nValue;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    int AdjustedHeight(int height, const Consensus::Params& params) 
+    {
+        auto daedalus_start = params.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].start_block;
+        return std::max(0, height - daedalus_start);
+    }
+
+    InviteStats InviteBuffer::get(int height, const Consensus::Params& params) const
+    {
+        LOCK(cs);
+
+        InviteStats s;
+
+        auto adjusted_height = AdjustedHeight(height, params);
+
+        //get cached value, otherwise we compute.
+        if(get(adjusted_height, s)) {
+            return s;
+        }
+
+        const auto index = chain[height];
+        if(!index) {
+            return s;
+        }
+
+        CBlock block;
+        if (!ReadBlockFromDisk(block, index, params, false)) {
+            return s;
+        }
+
+        if (!ComputeStats(block, s, params)) {
+            return s;
+        }
+
+        s.is_set = true;
+        insert(adjusted_height, s);
+        return s;
+    }
+
+    bool InviteBuffer::get(int adjusted_height, InviteStats& s) const
+    {
+        if(stats.size() <= adjusted_height) {
+            return false;
+        }
+
+        s = stats[adjusted_height];
+        return s.is_set;
+    }
+
+    void InviteBuffer::insert(int adjusted_height, const InviteStats& s) const
+    {
+        if(stats.size() <= adjusted_height) {
+            stats.resize(adjusted_height+1);
+        }
+        stats[adjusted_height] = s;
+    }
+
+} // namespace pog

--- a/src/pog/invitebuffer.h
+++ b/src/pog/invitebuffer.h
@@ -13,11 +13,33 @@
 
 namespace pog 
 {
-    struct InviteStats 
+    struct MeanStats
     {
         int invites_created = 0;
         int invites_used = 0;
+        int blocks = 0;
+        double mean_used = 0.0;
+
+        MeanStats() {}
+
+        MeanStats(
+                int created,
+                int used,
+                int blks,
+                double mean) :
+            invites_created{created},
+            invites_used{used},
+            blocks{blks},
+            mean_used{mean} {}
+    };
+
+    struct InviteStats 
+    {
+        MeanStats mean_stats;
+        int invites_created = 0;
+        int invites_used = 0;
         bool is_set = false;
+        bool mean_set = false;
     };
 
     class InviteBuffer
@@ -25,6 +47,9 @@ namespace pog
         public:
             InviteBuffer(const CChain& c);
             InviteStats get(int height, const Consensus::Params& p) const;
+            bool set_mean(int height, const MeanStats& mean_stats, const Consensus::Params& p);
+
+            bool drop(int height, const Consensus::Params& p);
 
         private:
             bool get(int adjusted_height, InviteStats& s) const;

--- a/src/pog/invitebuffer.h
+++ b/src/pog/invitebuffer.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2018 The Merit Foundation developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef MERIT_POG_INVITE_BUFFER_H
+#define MERIT_POG_INVITE_BUFFER_H
+
+#include "pog/reward.h"
+#include "chain.h"
+#include "sync.h"
+
+#include <vector>
+
+namespace pog 
+{
+    struct InviteStats 
+    {
+        int invites_created = 0;
+        int invites_used = 0;
+        bool is_set = false;
+    };
+
+    class InviteBuffer
+    {
+        public:
+            InviteBuffer(const CChain& c);
+            InviteStats get(int height, const Consensus::Params& p) const;
+
+        private:
+            bool get(int adjusted_height, InviteStats& s) const;
+            void insert(int adjusted_height, const InviteStats& s) const;
+
+        private:
+            mutable std::vector<InviteStats> stats;
+            mutable CCriticalSection cs;
+            const CChain& chain;
+    };
+
+} // namespace pog
+
+#endif //MERIT_POG_INVITE_BUFFER_H

--- a/src/pog/reward.cpp
+++ b/src/pog/reward.cpp
@@ -127,7 +127,7 @@ namespace pog
 
 
         int min_total_winners = 0;
-        if(block1.invites_created <= block1.blocks) {
+        if(block1.invites_created <= (block1.blocks / params.imp_miner_reward_for_every_x_blocks)) {
             min_total_winners = 
                 (block1.blocks / params.imp_min_one_invite_for_every_x_blocks);
         }

--- a/src/pog/reward.cpp
+++ b/src/pog/reward.cpp
@@ -134,6 +134,18 @@ namespace pog
         return total_winners;
     }
 
+    double ComputeUsedInviteMean(const InviteLotteryParams& lottery)
+    {
+        if(lottery.blocks <= 0) {
+            return 0.0;
+        }
+
+        auto mean = static_cast<double>(lottery.invites_used) /
+            static_cast<double>(lottery.blocks);
+        LogPrintf("Mean Invites Used %d:  used total: %d  created: %d blocks: %d\n", mean, lottery.invites_used, lottery.invites_created, lottery.blocks);
+        return mean;
+    }
+
     int ComputeTotalInviteLotteryWinners(
             int height,
             const InviteLotteryParams& lottery,

--- a/src/pog/reward.h
+++ b/src/pog/reward.h
@@ -48,6 +48,8 @@ namespace pog
         int invites_used = 0;
     };
 
+    using InviteLotteryParamsVec = std::vector<InviteLotteryParams>;
+
     int ComputeTotalInviteLotteryWinners(
             int height,
             const InviteLotteryParams&,

--- a/src/pog/reward.h
+++ b/src/pog/reward.h
@@ -46,7 +46,11 @@ namespace pog
     {
         int invites_created = 0;
         int invites_used = 0;
+        int blocks = 0;
+        double mean_used = 0.0;
     };
+
+    double ComputeUsedInviteMean(const InviteLotteryParams& lottery);
 
     using InviteLotteryParamsVec = std::vector<InviteLotteryParams>;
 

--- a/src/pog/reward.h
+++ b/src/pog/reward.h
@@ -56,7 +56,7 @@ namespace pog
 
     int ComputeTotalInviteLotteryWinners(
             int height,
-            const InviteLotteryParams&,
+            const InviteLotteryParamsVec&,
             const Consensus::Params& params);
 
     using InviteRewards = std::vector<InviteReward>;

--- a/src/validation.h
+++ b/src/validation.h
@@ -678,6 +678,14 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
  */
 bool ExpectDaedalus(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
+/**
+ * Returns true if the block can have a miner invite reward
+ */
+bool BlockHasMinerInviteReward(
+        int height,
+        const uint256& previous_block_hash,
+        const Consensus::Params& params);
+
 /** Reject codes greater or equal to this can be returned by AcceptToMemPool
  * for transactions, to signal internal conditions. They cannot and should not
  * be sent over the P2P network.


### PR DESCRIPTION
Stores stats of invites by block height. Also laid out groundwork for
computing and validating improved invite generation algorithm.

The stores stats will be used to memoize the computed moving averages
for a block height so that a slope can be computed easily and quickly.

The invites adjustment will handle exponential growth by adjusting the
rate linearly based on past data.