### PR TITLE
Include ancestors of referral confirmations.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -546,12 +546,15 @@ int BlockAssembler::UpdatePackagesForAdded(
 {
     int nDescendantsUpdated = 0;
     for (const CTxMemPool::txiter it : alreadyAdded) {
+
         CTxMemPool::setEntries descendants;
         mempool.CalculateDescendants(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
+
             if (alreadyAdded.count(desc))
                 continue;
+
             ++nDescendantsUpdated;
             modtxiter mit = mapModifiedTx.find(desc);
             if (mit == mapModifiedTx.end()) {

--- a/src/miner.h
+++ b/src/miner.h
@@ -91,8 +91,9 @@ struct CompareModifiedEntry {
         bool bi = b.iter->GetSharedEntryValue()->IsInvite();
 
         if(ai == bi) {
-            double f1 = (double)a.nModFeesWithAncestors * b.nSizeWithAncestors;
-            double f2 = (double)b.nModFeesWithAncestors * a.nSizeWithAncestors;
+            double f1 = (ai ? 1.0 : static_cast<double>(a.nModFeesWithAncestors)) * b.nSizeWithAncestors;
+            double f2 = (bi ? 1.0 : static_cast<double>(b.nModFeesWithAncestors)) * a.nSizeWithAncestors;
+
             if (f1 == f2) {
                 return CompareIteratorByHash<CTxMemPool::txiter>()(a.iter, b.iter);
             }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -254,7 +254,7 @@ void CTxMemPool::CalculateReferralsConfirmations(
         addresses.push_back({referral->GetAddress(), referral->addressType});
     }
 
-    mempool.getAddressIndex(addresses, indexes);
+    getAddressIndex(addresses, indexes);
 
     for (const auto& index: indexes) {
         auto it = mapTx.find(index.first.txhash);
@@ -271,7 +271,7 @@ void CTxMemPool::CalculateReferralsConfirmations(
             uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
             std::string dummy;
 
-            mempool.CalculateMemPoolAncestors(
+            CalculateMemPoolAncestors(
                     *it,
                     confirmations,
                     nNoLimit,
@@ -541,11 +541,11 @@ void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewC
 }
 
 bool CTxMemPool::getAddressIndex(std::vector<AddressPair> &addresses,
-                                 std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results)
+                                 std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results) const
 {
     LOCK(cs);
     for (std::vector<AddressPair>::iterator it = addresses.begin(); it != addresses.end(); it++) {
-        addressDeltaMap::iterator ait = mapAddress.lower_bound(CMempoolAddressDeltaKey((*it).second, (*it).first));
+        addressDeltaMap::const_iterator ait = mapAddress.lower_bound(CMempoolAddressDeltaKey((*it).second, (*it).first));
         while (ait != mapAddress.end() && (*ait).first.addressBytes == (*it).first && (*ait).first.type == (*it).second) {
             results.push_back(*ait);
             ait++;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -256,6 +256,9 @@ void CTxMemPool::CalculateReferralsConfirmations(
 
     getAddressIndex(addresses, indexes);
 
+    uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
+    std::string dummy;
+
     for (const auto& index: indexes) {
         auto it = mapTx.find(index.first.txhash);
         assert(it != mapTx.end());
@@ -268,8 +271,6 @@ void CTxMemPool::CalculateReferralsConfirmations(
                         static_cast<char>(index.first.type),
                         index.first.addressBytes}.ToString());
             confirmations.insert(it);
-            uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
-            std::string dummy;
 
             CalculateMemPoolAncestors(
                     *it,

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -262,12 +262,24 @@ void CTxMemPool::CalculateReferralsConfirmations(
 
         auto tx = it->GetSharedEntryValue();
         if (tx->IsInvite()) {
-            debug("Found confirmation in mempool: %s, %s",
+            debug("Found confirmation in mempool: %s, %s\n",
                     tx->GetHash().GetHex(),
                     CMeritAddress{
                         static_cast<char>(index.first.type),
                         index.first.addressBytes}.ToString());
             confirmations.insert(it);
+            uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
+            std::string dummy;
+
+            mempool.CalculateMemPoolAncestors(
+                    *it,
+                    confirmations,
+                    nNoLimit,
+                    nNoLimit,
+                    nNoLimit,
+                    nNoLimit,
+                    dummy,
+                    false);
         }
     }
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -502,7 +502,7 @@ public:
 
     void addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view);
     bool getAddressIndex(std::vector<AddressPair> &addresses,
-                         std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results);
+                         std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results) const;
     bool removeAddressIndex(const uint256 txhash);
 
     void addSpentIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -266,10 +266,10 @@ public:
         bool bi = b.IsInvite();
 
         if(ai == bi) {
-            double aFees = a.GetModFeesWithAncestors();
+            double aFees = a.IsInvite() ? 1.0 : a.GetModFeesWithAncestors();
             double aSize = a.GetSizeWithAncestors();
 
-            double bFees = b.GetModFeesWithAncestors();
+            double bFees = b.IsInvite() ? 1.0 : b.GetModFeesWithAncestors();
             double bSize = b.GetSizeWithAncestors();
 
             // Avoid division by rewriting (a/b > c/d) as (a*d > c*b).
@@ -286,6 +286,7 @@ public:
         return ai > bi;
     }
 };
+
 
 // Multi_index tag names
 struct descendant_score {};


### PR DESCRIPTION
Otherwise not all ancestors are included causing havoc.

Particularly an assert failure is caused during mining because the order transactions are included in the block is wrong.