### PR TITLE
Fix ambassador lottery sampling.

### DIFF
--- a/src/pog/select.cpp
+++ b/src/pog/select.cpp
@@ -7,6 +7,7 @@
 #include "clientversion.h"
 #include <algorithm>
 #include <iterator>
+#include "referrals.h"
 
 namespace pog
 {
@@ -275,7 +276,10 @@ namespace pog
      * Selecting winners from the distribution is deterministic and will return the same
      * N samples given the same input hash.
      */
-    referral::AddressANVs WalletSelector::Select(uint256 hash, size_t n) const
+    referral::AddressANVs WalletSelector::Select(
+            const referral::ReferralsViewCache& referrals,
+            uint256 hash,
+            size_t n) const
     {
         assert(n <= m_distribution.Size());
         referral::AddressANVs samples;
@@ -288,7 +292,11 @@ namespace pog
             hasher << hash << sampled.address;
             hash = hasher.GetHash();
 
-            samples.push_back(sampled);
+            if(referrals.IsConfirmed(sampled.address)) {
+                samples.push_back(sampled);
+            } else {
+                n++;
+            }
         }
 
         return samples;

--- a/src/pog/select.cpp
+++ b/src/pog/select.cpp
@@ -277,6 +277,7 @@ namespace pog
      * N samples given the same input hash.
      */
     referral::AddressANVs WalletSelector::Select(
+            bool check_confirmations,
             const referral::ReferralsViewCache& referrals,
             uint256 hash,
             size_t n) const
@@ -292,7 +293,7 @@ namespace pog
             hasher << hash << sampled.address;
             hash = hasher.GetHash();
 
-            if(referrals.IsConfirmed(sampled.address)) {
+            if(!check_confirmations || referrals.IsConfirmed(sampled.address)) {
                 samples.push_back(sampled);
             } else {
                 n++;

--- a/src/pog/select.h
+++ b/src/pog/select.h
@@ -41,6 +41,7 @@ namespace pog
             WalletSelector(int height, const referral::AddressANVs& anvs);
 
             referral::AddressANVs Select(
+                    bool check_confirmations,
                     const referral::ReferralsViewCache& referrals,
                     uint256 hash,
                     size_t n) const;

--- a/src/pog/select.h
+++ b/src/pog/select.h
@@ -12,6 +12,11 @@
 
 #include <map>
 
+namespace referral
+{
+    class ReferralsViewCache;
+}
+
 namespace pog
 {
     using InvertedAnvs = referral::AddressANVs;
@@ -35,7 +40,10 @@ namespace pog
         public:
             WalletSelector(int height, const referral::AddressANVs& anvs);
 
-            referral::AddressANVs Select(uint256 hash, size_t n) const;
+            referral::AddressANVs Select(
+                    const referral::ReferralsViewCache& referrals,
+                    uint256 hash,
+                    size_t n) const;
 
             size_t Size() const;
         private:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1820,6 +1820,9 @@ pog::AmbassadorLottery RewardAmbassadors(
     assert(height >= 0);
     assert(prefviewdb != nullptr);
 
+    const bool is_daedalus = 
+        height >= params.vDeployments[Consensus::DEPLOYMENT_DAEDALUS].start_block;
+
     static size_t max_embassador_lottery = 0;
     referral::AddressANVs entrants;
 
@@ -1848,6 +1851,7 @@ pog::AmbassadorLottery RewardAmbassadors(
 
     // Select the N winners using the previous block hash as the seed
     auto winners = selector.Select(
+            is_daedalus,
             *prefviewcache,
             previous_block_hash,
             desired_winners);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1847,7 +1847,10 @@ pog::AmbassadorLottery RewardAmbassadors(
     assert(desired_winners < 100);
 
     // Select the N winners using the previous block hash as the seed
-    auto winners = selector.Select(previous_block_hash, desired_winners);
+    auto winners = selector.Select(
+            *prefviewcache,
+            previous_block_hash,
+            desired_winners);
 
     assert(winners.size() == desired_winners);
 
@@ -2124,7 +2127,6 @@ void PayAmbassadors(const pog::AmbassadorLottery& lottery, CMutableTransaction& 
                 }
 
                 debug("\tWinner: %s, %d", addr.ToString(), static_cast<int>(winner.address_type));
-
                 const auto script = GetScriptForDestination(dest);
                 return CTxOut{winner.amount, script};
             });
@@ -5444,6 +5446,10 @@ bool CheckAddressConfirmed(const uint160& addr, char addr_type, bool checkMempoo
 
     if (confirmed) {
         return true;
+    }
+
+    if(!checkMempool) { 
+        return false;
     }
 
     // check mempool for confirmation invite transaction


### PR DESCRIPTION
Ignore unconfirmed beacons that were previously mined.