### PR TITLE
Fix GlobalSend transactions.

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -207,7 +207,8 @@ bool Consensus::CheckTxOutputs(
         CValidationState& state,
         const referral::ReferralsViewCache& referralsCache,
         const std::vector<referral::ReferralRef>& vExtraReferrals,
-        const ConfirmationSet* block_invites)
+        const ConfirmationSet* block_invites,
+        bool check_mempool)
 {
     // check addresses used for vouts are beaconed
     for (const auto& txout: tx.vout) {
@@ -247,7 +248,7 @@ bool Consensus::CheckTxOutputs(
         }
 
         if (!tx.IsInvite() && ExpectDaedalus(chainActive.Tip(), ::Params().GetConsensus())) {
-            if (!CheckAddressConfirmed(CMeritAddress{dest}, false)) {
+            if (!CheckAddressConfirmed(CMeritAddress{dest}, check_mempool)) {
                 if (block_invites != nullptr) {
                     if (block_invites->count(addr) == 0) {
                         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-not-confirmed");

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -47,7 +47,8 @@ bool CheckTxOutputs(
         CValidationState& state,
         const referral::ReferralsViewCache& referralsCache,
         const std::vector<referral::ReferralRef>& vExtraReferrals,
-        const ConfirmationSet* block_invites = nullptr);
+        const ConfirmationSet* block_invites = nullptr,
+        bool check_mempool = false);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -417,7 +417,12 @@ bool BlockAssembler::CheckReferrals(
         const auto tx = it->GetEntryValue();
 
         CValidationState dummy;
-        if (!Consensus::CheckTxOutputs(tx, dummy, *prefviewcache, candidate_referrals)) {
+        if (!Consensus::CheckTxOutputs(
+                    tx,
+                    dummy,
+                    *prefviewcache,
+                    candidate_referrals,
+                    &confirmations)) {
             return false;
         }
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -935,7 +935,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins, const referral::ReferralsV
             CValidationState state;
             bool fCheckResult = tx.IsCoinBase() ||
                 (Consensus::CheckTxInputs(tx, state, mempoolDuplicate, nSpendHeight) &&
-                Consensus::CheckTxOutputs(tx, state, referralsCache, refs));
+                Consensus::CheckTxOutputs(tx, state, referralsCache, refs, nullptr, true));
             assert(fCheckResult);
             UpdateCoins(tx, mempoolDuplicate, 1000000);
         }
@@ -952,7 +952,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins, const referral::ReferralsV
         } else {
             bool fCheckResult = entry->GetEntryValue().IsCoinBase() ||
                 (Consensus::CheckTxInputs(entry->GetEntryValue(), state, mempoolDuplicate, nSpendHeight) &&
-                Consensus::CheckTxOutputs(entry->GetEntryValue(), state, referralsCache, refs));
+                Consensus::CheckTxOutputs(entry->GetEntryValue(), state, referralsCache, refs, nullptr, true));
             assert(fCheckResult);
             UpdateCoins(entry->GetEntryValue(), mempoolDuplicate, 1000000);
             stepsSinceLastRemove = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1296,7 +1296,9 @@ static bool AcceptToMemoryPoolWorker(
                     tx,
                     state,
                     *prefviewcache,
-                    mempoolReferral.GetReferrals())) {
+                    mempoolReferral.GetReferrals(),
+                    nullptr,
+                    true)) {
 
             return false;
         }


### PR DESCRIPTION
A prior bug fix revealed another bug and prevented GlobalSends from
working.

This commit makes sure mempool lookups use the mempool in CheckTxOuts
in contexts where CheckTxOuts are not validating a block.