### PR TITLE
Mnemonic Encryption

### DIFF
--- a/src/qt/importwalletdialog.cpp
+++ b/src/qt/importwalletdialog.cpp
@@ -15,6 +15,7 @@
 #include "qrutil.h"
 #include "walletmodel.h"
 #include "importwalletdialog.h"
+#include "ui_interface.h"
 #include "ui_importwalletdialog.h"
 #include "crypto/mnemonic/mnemonic.h"
 
@@ -28,6 +29,7 @@ ImportWalletDialog::ImportWalletDialog(QWidget *parent, WalletModel *model) :
     connect(ui->cancelButton, SIGNAL(clicked()), this, SLOT(OnCancelClicked()));
     connect(ui->importButton, SIGNAL(clicked()), this, SLOT(ImportWallet()));
     connect(ui->mnemonic, SIGNAL(textChanged()), this, SLOT(UpdateImportButton()));
+    uiInterface.ShowProgress.connect([](const std::string&, int){});
 
     ui->importButton->setEnabled(false);
     ui->progressTitle->setVisible(false);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -912,3 +912,9 @@ bool WalletModel::ImportMnemonicAsMaster(const std::string& mnemonic)
     assert(wallet);
     return wallet->ImportMnemonicAsMaster(mnemonic);
 }
+
+bool WalletModel::CryptedWalletNeedsNewPassphrase() const
+{
+    assert(wallet);
+    return wallet->CryptedWalletNeedsNewPassphrase();
+}

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -240,6 +240,7 @@ public:
 
     bool IsAValidMnemonic(const std::string& mnemonic);
     bool ImportMnemonicAsMaster(const std::string& mnemonic);
+    bool CryptedWalletNeedsNewPassphrase() const;
 
 private:
     CWallet *wallet;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -151,6 +151,9 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
 
         // Show progress dialog
         connect(_walletModel, SIGNAL(showProgress(QString,int)), this, SLOT(showProgress(QString,int)));
+
+        connect(_walletModel, SIGNAL(showProgress(QString,int)), this, SLOT(showProgress(QString,int)));
+        QTimer::singleShot(3000, this, SLOT(CheckChangePassphrase()));
     }
 }
 
@@ -285,6 +288,29 @@ void WalletView::changePassphrase()
     AskPassphraseDialog dlg(AskPassphraseDialog::ChangePass, this);
     dlg.setModel(walletModel);
     dlg.exec();
+}
+
+void WalletView::CheckChangePassphrase()
+{
+    assert(walletModel);
+    if(!walletModel->IsReferred()) {
+        return;
+    }
+
+    if(walletModel->CryptedWalletNeedsNewPassphrase()) {
+        QMessageBox msgBox{QMessageBox::Question,
+            "Insecure Mnemonic", 
+            "It looks like your wallet's mnemonic was not encrypted. "
+            "We recommend you change your passphrase to encrypt it. Do "
+            "you want to change your passphrase now?",
+            QMessageBox::Yes | QMessageBox::No,
+            this};
+        msgBox.setStyleSheet(QString("QMessageBox { background-color: white; }"));
+        auto ret = msgBox.exec();
+        if(ret != QMessageBox::Yes) {
+            return;
+        }
+    }
 }
 
 void WalletView::unlockWallet()

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -97,6 +97,8 @@ public Q_SLOTS:
     void backupWallet();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
+    /** Check to see if passphrase change is nessasary*/
+    void CheckChangePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */
     void unlockWallet();
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -110,7 +110,11 @@ bool CCrypter::Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingM
 }
 
 
-static bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMaterial &vchPlaintext, const uint256& nIV, std::vector<unsigned char> &vchCiphertext)
+bool EncryptSecret(
+        const CKeyingMaterial& vMasterKey,
+        const CKeyingMaterial &vchPlaintext,
+        const uint256& nIV,
+        std::vector<unsigned char> &vchCiphertext)
 {
     CCrypter cKeyCrypter;
     std::vector<unsigned char> chIV(WALLET_CRYPTO_IV_SIZE);
@@ -120,7 +124,11 @@ static bool EncryptSecret(const CKeyingMaterial& vMasterKey, const CKeyingMateri
     return cKeyCrypter.Encrypt(*((const CKeyingMaterial*)&vchPlaintext), vchCiphertext);
 }
 
-static bool DecryptSecret(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCiphertext, const uint256& nIV, CKeyingMaterial& vchPlaintext)
+bool DecryptSecret(
+        const CKeyingMaterial& vMasterKey,
+        const std::vector<unsigned char>& vchCiphertext,
+        const uint256& nIV,
+        CKeyingMaterial& vchPlaintext)
 {
     CCrypter cKeyCrypter;
     std::vector<unsigned char> chIV(WALLET_CRYPTO_IV_SIZE);
@@ -204,6 +212,18 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
     }
     NotifyStatusChanged(this);
     return true;
+}
+
+bool CCryptoKeyStore::DecryptSecret(
+        const std::vector<unsigned char>& ciphertext,
+        const uint256& IV,
+        CKeyingMaterial& plaintext) const
+{
+    if (!IsCrypted()) {
+        return false;
+    }
+
+    return ::DecryptSecret(vMasterKey, ciphertext, IV, plaintext);
 }
 
 bool CCryptoKeyStore::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -133,6 +133,11 @@ protected:
     bool Unlock(const CKeyingMaterial& vMasterKeyIn);
     CryptedKeyMap mapCryptedKeys;
 
+    bool DecryptSecret(
+            const std::vector<unsigned char>& vchCiphertext,
+            const uint256& nIV,
+            CKeyingMaterial& vchPlaintext) const;
+
 public:
     CCryptoKeyStore() : fUseCrypto(false), fDecryptionThoroughlyChecked(false)
     {
@@ -193,5 +198,18 @@ public:
      */
     boost::signals2::signal<void (CCryptoKeyStore* wallet)> NotifyStatusChanged;
 };
+
+bool EncryptSecret(
+        const CKeyingMaterial& vMasterKey,
+        const CKeyingMaterial &vchPlaintext,
+        const uint256& nIV,
+        std::vector<unsigned char> &vchCiphertext);
+
+bool DecryptSecret(
+        const CKeyingMaterial& vMasterKey,
+        const std::vector<unsigned char>& vchCiphertext,
+        const uint256& nIV,
+        CKeyingMaterial& vchPlaintext);
+
 
 #endif // MERIT_WALLET_CRYPTER_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4147,6 +4147,16 @@ UniValue getmnemonic(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
+    if (pwallet->IsLocked()) {
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
+    }
+
+    if(pwallet->CryptedWalletNeedsNewPassphrase()) {
+        throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, 
+                "Error: You have an encrypted wallet but your mnemonic is not"
+                " encrypted. Please change the passphrase using walletpassphrasechange to secure it.");
+    }
+
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
             "getmnemonic\n"
@@ -4169,7 +4179,7 @@ UniValue getmnemonic(const JSONRPCRequest& request)
 
     CKeyID masterKeyID = pwallet->GetHDChain().masterKeyID;
     if (!masterKeyID.IsNull()) {
-        std::string mnemonic = pwallet->mapKeyMetadata[masterKeyID].mnemonic;
+        auto mnemonic = pwallet->GetMnemonic();
 
         if(mnemonic.length() == 0)
             throw JSONRPCError(RPC_WALLET_NO_MNEMONIC,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -946,6 +946,7 @@ public:
     void UnlockCoin(const COutPoint& output);
     void UnlockAllCoins();
     void ListLockedCoins(std::vector<COutPoint>& vOutpts) const;
+    bool EncryptMnemonic(CKeyingMaterial& master_key);
 
     /*
      * Rescan abort properties
@@ -1008,6 +1009,7 @@ public:
     bool Unlock(const SecureString& strWalletPassphrase);
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
+    bool CryptedWalletNeedsNewPassphrase() const;
 
     void GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const;
     unsigned int ComputeTimeSmart(const CWalletTx& wtx) const;
@@ -1235,8 +1237,8 @@ public:
     void postInitProcess(CScheduler& scheduler);
 
     bool BackupWallet(const std::string& strDest);
-    bool HasMnemonic();
-    std::string GetMnemonic();
+    bool HasMnemonic() const;
+    std::string GetMnemonic() const;
 
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(const CHDChain& chain, bool memonly);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -946,7 +946,7 @@ public:
     void UnlockCoin(const COutPoint& output);
     void UnlockAllCoins();
     void ListLockedCoins(std::vector<COutPoint>& vOutpts) const;
-    bool EncryptMnemonic(CKeyingMaterial& master_key);
+    bool EncryptMnemonic(CWalletDB&, CKeyingMaterial& master_key);
 
     /*
      * Rescan abort properties

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -58,14 +58,20 @@ bool CWalletDB::EraseTx(uint256 hash)
     return EraseIC(std::make_pair(std::string("tx"), hash));
 }
 
-bool CWalletDB::WriteKeyMetadata(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta)
+bool CWalletDB::WriteKeyMetadata(
+        const CPubKey& vchPubKey,
+        const CKeyMetadata& keyMeta,
+        bool overwrite)
 {
-   return WriteIC(std::make_pair(std::string("keymeta"), vchPubKey), keyMeta, false);
+   return WriteIC(std::make_pair(std::string("keymeta"), vchPubKey), keyMeta, overwrite);
 }
 
-bool CWalletDB::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata& keyMeta)
+bool CWalletDB::WriteKey(
+        const CPubKey& vchPubKey,
+        const CPrivKey& vchPrivKey,
+        const CKeyMetadata& keyMeta)
 {
-    if(!WriteKeyMetadata(vchPubKey, keyMeta)) {
+    if(!WriteKeyMetadata(vchPubKey, keyMeta, false)) {
         return false;
     }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -58,9 +58,14 @@ bool CWalletDB::EraseTx(uint256 hash)
     return EraseIC(std::make_pair(std::string("tx"), hash));
 }
 
+bool CWalletDB::WriteKeyMetadata(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta)
+{
+   return WriteIC(std::make_pair(std::string("keymeta"), vchPubKey), keyMeta, false);
+}
+
 bool CWalletDB::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata& keyMeta)
 {
-    if (!WriteIC(std::make_pair(std::string("keymeta"), vchPubKey), keyMeta, false)) {
+    if(!WriteKeyMetadata(vchPubKey, keyMeta)) {
         return false;
     }
 
@@ -77,7 +82,7 @@ bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
                                 const std::vector<unsigned char>& vchCryptedSecret,
                                 const CKeyMetadata &keyMeta)
 {
-    if (!WriteIC(std::make_pair(std::string("keymeta"), vchPubKey), keyMeta)) {
+    if(!WriteKeyMetadata(vchPubKey, keyMeta)) {
         return false;
     }
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -103,7 +103,7 @@ public:
     static const int VERSION_WITH_HDDATA=10;
     static const int VERSION_WITH_MNEMONIC=11;
     static const int VERSION_WITH_SECURE_MNEMONIC=12;
-    static const int CURRENT_VERSION=VERSION_WITH_MNEMONIC;
+    static const int CURRENT_VERSION=VERSION_WITH_HDDATA;
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
     std::string hdKeypath; //optional HD/bip32 keypath
@@ -190,7 +190,7 @@ public:
     bool WriteTx(const CWalletTx& wtx);
     bool EraseTx(uint256 hash);
 
-    bool WriteKeyMetadata(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta);
+    bool WriteKeyMetadata(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta, bool overwrite = true);
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -102,7 +102,8 @@ public:
     static const int VERSION_BASIC=1;
     static const int VERSION_WITH_HDDATA=10;
     static const int VERSION_WITH_MNEMONIC=11;
-    static const int CURRENT_VERSION=VERSION_WITH_HDDATA;
+    static const int VERSION_WITH_SECURE_MNEMONIC=12;
+    static const int CURRENT_VERSION=VERSION_WITH_MNEMONIC;
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
     std::string hdKeypath; //optional HD/bip32 keypath
@@ -189,6 +190,7 @@ public:
     bool WriteTx(const CWalletTx& wtx);
     bool EraseTx(uint256 hash);
 
+    bool WriteKeyMetadata(const CPubKey& vchPubKey, const CKeyMetadata& keyMeta);
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);
     bool WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey);


### PR DESCRIPTION
The mnemonic code implementation did not properly encrypt the mnemonics when the wallet was encrypted. This code makes sure the mnemonics are encrypted and that users with previously encrypted wallets create a new passphrase and encrypt their wallets to migrate.