### PR TITLE
Fix network difficulty calculation

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -70,17 +70,12 @@ double GetDifficulty(const CBlockIndex* blockindex)
     int nShift = (blockindex->nBits >> 24) & 0xff;
 
     double dDiff =
-        (double)0x0000ffff / (double)(blockindex->nBits & 0x00ffffff);
+        (double)0x007fff80 / (double)(blockindex->nBits & 0x00ffffff);
 
-    while (nShift < 29)
+    while (nShift < 32)
     {
         dDiff *= 256.0;
         nShift++;
-    }
-    while (nShift > 29)
-    {
-        dDiff /= 256.0;
-        nShift--;
     }
 
     return dDiff;


### PR DESCRIPTION
We're calculating difficulty for wrong initial target. It should be calculated for 0x207fff80 instead 0x1d00ffff, then target/difficulty/hashpower calculation corresponds with bitcoin math https://en.bitcoin.it/wiki/Difficulty and network difficulty would look like 2523.66610963431 instead 1.494...e-06