### PR TITLE
Enlarge constant to fix error "Transaction too large"

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -30,7 +30,7 @@ static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
 /** The maximum weight for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
+static const unsigned int MAX_STANDARD_TX_WEIGHT = 4000000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -19,14 +19,14 @@ class CCoinsViewCache;
 class CTxOut;
 
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 16000000;
 /**
  * Default for -blocktxsmaxsizeshare, which controls the maximum share of transacitons size in block the mining code will create
  * Left space is used for referrals
  */
 static const unsigned int DEFAULT_BLOCK_TRANSACTIONS_MAX_SIZE_SHARE = 90;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
+static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT =16000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
 /** The maximum weight for transactions we're willing to relay/mine */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -30,7 +30,7 @@ static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT =16000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
 /** The maximum weight for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_WEIGHT = 1000000;
+static const unsigned int MAX_STANDARD_TX_WEIGHT = 6400000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -30,7 +30,7 @@ static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
 /** The maximum weight for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_WEIGHT = 4000000;
+static const unsigned int MAX_STANDARD_TX_WEIGHT = 1000000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */


### PR DESCRIPTION
value equals to the third of block size