### PR TITLE
Performance enhancements

### DIFF
--- a/src/pog/anv.cpp
+++ b/src/pog/anv.cpp
@@ -24,12 +24,13 @@ namespace pog
     }
 
     void GetAllRewardableANVs(
-            const referral::ReferralsViewDB& db,
+            const referral::ReferralsViewCache& db,
             const Consensus::Params& params,
             int height,
-            referral::AddressANVs& entrants)
+            referral::AddressANVs& entrants,
+            bool cached)
     {
-        db.GetAllRewardableANVs(params, height, entrants);
+        db.GetAllRewardableANVs(params, height, entrants, cached);
     }
 
     referral::AddressANVs GetANVs(

--- a/src/pog/anv.h
+++ b/src/pog/anv.h
@@ -8,6 +8,7 @@
 #include "primitives/referral.h"
 #include "consensus/params.h"
 #include "refdb.h"
+#include "referrals.h"
 
 #include <vector>
 
@@ -28,10 +29,11 @@ namespace pog
     referral::AddressANVs GetAllANVs(const referral::ReferralsViewDB&);
 
     void GetAllRewardableANVs(
-            const referral::ReferralsViewDB&,
+            const referral::ReferralsViewCache&,
             const Consensus::Params&,
             int height,
-            referral::AddressANVs&);
+            referral::AddressANVs&, 
+            bool cached = false);
 
 } // namespace pog
 

--- a/src/referrals.cpp
+++ b/src/referrals.cpp
@@ -269,5 +269,21 @@ MaybeConfirmedAddress ReferralsViewCache::GetConfirmation(const Address& address
     return m_db->GetConfirmation(ref->addressType, address);
 }
 
+void ReferralsViewCache::GetAllRewardableANVs(
+        const Consensus::Params& params,
+        int height,
+        AddressANVs& anvs,
+        bool cached) const
+{
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    if(cached && !all_rewardable_anvs.empty()) {
+        anvs = all_rewardable_anvs; 
+        return;
+    } 
+
+    assert(m_db);
+    m_db->GetAllRewardableANVs(params, height, anvs);
+    all_rewardable_anvs = anvs;
+}
 
 }

--- a/src/referrals.h
+++ b/src/referrals.h
@@ -21,6 +21,7 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/optional.hpp>
 #include <unordered_map>
+#include <mutex>
 
 using namespace boost::multi_index;
 
@@ -70,6 +71,8 @@ private:
     mutable ReferralIndex referrals_index;
     mutable AliasIndex alias_index;
     mutable ConfirmationsIndex confirmations_index;
+    mutable AddressANVs all_rewardable_anvs;
+    mutable std::mutex cache_mutex;
 
     void InsertReferralIntoCache(const Referral&) const;
     void RemoveAliasFromCache(const Referral&) const;
@@ -115,6 +118,11 @@ public:
 
     // Get address confirmations
     MaybeConfirmedAddress GetConfirmation(const Address& address) const;
+
+    void GetAllRewardableANVs(
+            const Consensus::Params& params,
+            int height,
+            AddressANVs&, bool cached = false) const;
 };
 
 } // namespace referral

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -152,10 +152,6 @@ UniValue validateaddress(const JSONRPCRequest& request)
 
 #ifdef ENABLE_WALLET
     CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
-
-    LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : nullptr);
-#else
-    LOCK(cs_main);
 #endif
     const auto intput_id = request.params[0].get_str();
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1832,7 +1832,7 @@ pog::AmbassadorLottery RewardAmbassadors(
     auto reserve_size = max_ambassador_lottery * 1.5;
     entrants.reserve(reserve_size);
 
-    pog::GetAllRewardableANVs(*prefviewdb, params, height, entrants);
+    pog::GetAllRewardableANVs(*prefviewcache, params, height, entrants);
 
     max_ambassador_lottery = std::max(max_ambassador_lottery, entrants.size());
 
@@ -7302,7 +7302,7 @@ std::pair<Ranks, size_t> ANVRanks(
     auto reserve_size = max_ambassador_lottery * 1.5;
     entrants.reserve(reserve_size);
 
-    pog::GetAllRewardableANVs(*prefviewdb, params, height, entrants);
+    pog::GetAllRewardableANVs(*prefviewcache, params, height, entrants, true);
 
     max_ambassador_lottery = std::max(max_ambassador_lottery, entrants.size());
 
@@ -7342,7 +7342,7 @@ std::pair<Ranks, size_t> TopANVRanks(
     auto reserve_size = max_ambassador_lottery * 1.5;
     entrants.reserve(reserve_size);
 
-    pog::GetAllRewardableANVs(*prefviewdb, params, height, entrants);
+    pog::GetAllRewardableANVs(*prefviewcache, params, height, entrants, true);
 
     max_ambassador_lottery = std::max(max_ambassador_lottery, entrants.size());
     total = std::min(total, entrants.size());


### PR DESCRIPTION
Some performance enhancements for getaddressrank, getaddressleaderboard and validateaddress.

getaddressrank: use new in memory cache of rewardable anvs
getaddressleaderboard: use new in memory cache of rewardable anvs
validateaddress: don't lock on lookup since leveldb will do that on gets.