### PR TITLE
Fix serialization size for CUnspentAddressKey

### DIFF
--- a/src/addressindex.h
+++ b/src/addressindex.h
@@ -20,7 +20,7 @@ struct CAddressUnspentKey {
     bool isInvite;
 
     size_t GetSerializeSize() const {
-        return 57;
+        return 58;
     }
     template<typename Stream>
     void Serialize(Stream& s) const {
@@ -35,14 +35,8 @@ struct CAddressUnspentKey {
     template<typename Stream>
     void Unserialize(Stream& s) {
         unsigned int encoded_type = ser_readdata8(s);
-
-        if(encoded_type >= 10) {
-            type = encoded_type - 10;
-            isInvite = true;
-        } else {
-            type = encoded_type;
-            isInvite = false;
-        }
+        isInvite = encoded_type >= 10;
+        type = isInvite ? encoded_type - 10 : encoded_type;
 
         hashBytes.Unserialize(s);
         txhash.Unserialize(s);


### PR DESCRIPTION
Forgot to count isCoinbase. Also simplified the deserialization logic.