### PR TITLE
Fix PoG2 invite distribution counts.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -193,6 +193,9 @@ public:
         consensus.pog2_convex_b = 0.2; 
         consensus.pog2_convex_s = 0.05;
 
+        // Fix invite lottery distribution amount.
+        consensus.imp_fix_invites_blockheight = 347039;
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -355,6 +358,9 @@ public:
         consensus.pog2_convex_b = 0.2; 
         consensus.pog2_convex_s = 0.05;
 
+        // Fix invite lottery distribution amount.
+        consensus.imp_fix_invites_blockheight = 226768;
+
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -495,6 +501,8 @@ public:
         consensus.pog2_max_outstanding_invites_per_address = 50;
         consensus.pog2_convex_b = 0.2; 
         consensus.pog2_convex_s = 0.05;
+
+        consensus.imp_fix_invites_blockheight = 20;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -194,7 +194,7 @@ public:
         consensus.pog2_convex_s = 0.05;
 
         // Fix invite lottery distribution amount.
-        consensus.imp_fix_invites_blockheight = 347039;
+        consensus.imp_fix_invites_blockheight = 347900;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -359,7 +359,7 @@ public:
         consensus.pog2_convex_s = 0.05;
 
         // Fix invite lottery distribution amount.
-        consensus.imp_fix_invites_blockheight = 226768;
+        consensus.imp_fix_invites_blockheight = 226904;
 
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -103,6 +103,9 @@ struct Params {
     int imp_miner_reward_for_every_x_blocks;
     std::vector<double> imp_weights;
 
+    /** Bug Fix height for invite lottery amount */ 
+    int imp_fix_invites_blockheight;
+
     /** PoG version 2 */
     int pog2_blockheight;
     int64_t pog2_total_winning_ambassadors;

--- a/src/pog/invitebuffer.cpp
+++ b/src/pog/invitebuffer.cpp
@@ -64,6 +64,7 @@ namespace pog
                     }
 
                     stats.invites_used += std::min(coinbase_used, beacons_invited);
+                    stats.invites_used_fixed += beacons_invited;
 
                 } else {
                     stats.invites_used += coinbase_used;

--- a/src/pog/invitebuffer.h
+++ b/src/pog/invitebuffer.h
@@ -17,20 +17,26 @@ namespace pog
     {
         int invites_created = 0;
         int invites_used = 0;
+        int invites_used_fixed = 0;
         int blocks = 0;
         double mean_used = 0.0;
+        double mean_used_fixed = 0.0;
 
         MeanStats() {}
 
         MeanStats(
                 int created,
                 int used,
+                int used_fixed,
                 int blks,
-                double mean) :
+                double mean,
+                double mean_fixed) :
             invites_created{created},
             invites_used{used},
+            invites_used_fixed{used_fixed},
             blocks{blks},
-            mean_used{mean} {}
+            mean_used{mean},
+            mean_used_fixed{mean_fixed} {}
     };
 
     struct InviteStats 
@@ -38,6 +44,7 @@ namespace pog
         MeanStats mean_stats;
         int invites_created = 0;
         int invites_used = 0;
+        int invites_used_fixed = 0;
         bool is_set = false;
         bool mean_set = false;
     };

--- a/src/pog/reward.cpp
+++ b/src/pog/reward.cpp
@@ -73,7 +73,7 @@ namespace pog
             const InviteLotteryParams& lottery,
             const Consensus::Params& params)
     {
-        LogPrint(BCLog::VALIDATION, "Invites used: %d created: %d period: %d used per block: %d\n",
+        LogPrint(BCLog::POG, "Invites used: %d created: %d period: %d used per block: %d\n",
                 lottery.invites_used,
                 lottery.invites_created,
                 params.daedalus_block_window,
@@ -125,7 +125,7 @@ namespace pog
         const auto& block1 = lottery_points[0];
         const auto& block2 = lottery_points[1];
 
-        LogPrint(BCLog::VALIDATION, "Invites used: %d created: %d period: %d used per block: %d\n",
+        LogPrint(BCLog::POG, "Invites used: %d created: %d period: %d used per block: %d\n",
                 block1.invites_used,
                 block1.invites_created,
                 params.daedalus_block_window,
@@ -161,6 +161,17 @@ namespace pog
         }
 
         auto mean = static_cast<double>(lottery.invites_used) /
+            static_cast<double>(lottery.blocks);
+        return mean;
+    }
+
+    double ComputeUsedInviteMeanFixed(const InviteLotteryParams& lottery)
+    {
+        if(lottery.blocks <= 0) {
+            return 0.0;
+        }
+
+        auto mean = static_cast<double>(lottery.invites_used_fixed) /
             static_cast<double>(lottery.blocks);
         return mean;
     }

--- a/src/pog/reward.h
+++ b/src/pog/reward.h
@@ -46,11 +46,14 @@ namespace pog
     {
         int invites_created = 0;
         int invites_used = 0;
+        int invites_used_fixed = 0;
         int blocks = 0;
         double mean_used = 0.0;
+        double mean_used_fixed = 0.0;
     };
 
     double ComputeUsedInviteMean(const InviteLotteryParams& lottery);
+    double ComputeUsedInviteMeanFixed(const InviteLotteryParams& lottery);
 
     using InviteLotteryParamsVec = std::vector<InviteLotteryParams>;
 

--- a/src/pog2/reward.h
+++ b/src/pog2/reward.h
@@ -23,6 +23,10 @@ namespace pog2
             const pog::InviteLotteryParamsVec&,
             const Consensus::Params& params);
 
+    int ComputeTotalInviteLotteryWinnersWithAmountFix(
+            const pog::InviteLotteryParamsVec&,
+            const Consensus::Params& params);
+
     pog::InviteRewards RewardInvites(const referral::ConfirmedAddresses& winners);
 
 } // namespace pog2

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2083,8 +2083,10 @@ bool OldComputeInviteLotteryParams(
     pog::MeanStats mean_stats {
         lottery_params.invites_created,
             lottery_params.invites_used,
+            0,
             lottery_params.blocks,
-            lottery_params.mean_used
+            lottery_params.mean_used,
+            0 
     };
 
     inviteBuffer.set_mean(prevHeight, mean_stats, params);
@@ -2117,6 +2119,7 @@ bool ImpComputeInviteLotteryParams(
 
     if (stats.mean_set) {
         lottery_params.invites_used = stats.mean_stats.invites_used;
+        lottery_params.invites_used_fixed = stats.mean_stats.invites_used_fixed;
         lottery_params.invites_created = stats.mean_stats.invites_created;
         lottery_params.blocks = stats.mean_stats.blocks;
         lottery_params.mean_used = stats.mean_stats.mean_used;
@@ -2136,6 +2139,7 @@ bool ImpComputeInviteLotteryParams(
 
         period_params.invites_created += stats.invites_created;
         period_params.invites_used += stats.invites_used;
+        period_params.invites_used_fixed += stats.invites_used_fixed;
 
         pindexPrev = pindexPrev->pprev;
 
@@ -2152,18 +2156,23 @@ bool ImpComputeInviteLotteryParams(
         const auto& w = params.imp_weights[i];
         lottery_params.invites_created += p.invites_created;
         lottery_params.invites_used += w*p.invites_used;
+        lottery_params.invites_used_fixed += w*p.invites_used_fixed;
     }
 
     lottery_params.invites_created /= params.imp_weights.size();
     lottery_params.invites_used /= 100;
+    lottery_params.invites_used_fixed /= 100;
     lottery_params.blocks=period_length;
     lottery_params.mean_used = pog::ComputeUsedInviteMean(lottery_params);
+    lottery_params.mean_used_fixed = pog::ComputeUsedInviteMeanFixed(lottery_params);
 
     pog::MeanStats mean_stats {
         lottery_params.invites_created,
             lottery_params.invites_used,
+            lottery_params.invites_used_fixed,
             lottery_params.blocks,
-            lottery_params.mean_used
+            lottery_params.mean_used,
+            lottery_params.mean_used_fixed
     };
 
     inviteBuffer.set_mean(prevHeight, mean_stats, params);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2240,12 +2240,16 @@ bool RewardInvites(
         return false;
     }
 
-    const bool pog2 = force_pog2 || height >= params.pog2_blockheight;
-    assert(!pog2 || cgs_selector);
+    size_t total_winners = 0;
 
-    const auto total_winners = pog2 ? 
-        pog2::ComputeTotalInviteLotteryWinners(lottery_params, params) :
-        pog::ComputeTotalInviteLotteryWinners(height, lottery_params, params);
+    const bool pog2 = height >= params.pog2_blockheight;
+    if(force_pog2 || height >= params.imp_fix_invites_blockheight) {
+        total_winners = pog2::ComputeTotalInviteLotteryWinnersWithAmountFix(lottery_params, params);
+    } else if(pog2) { 
+        total_winners = pog2::ComputeTotalInviteLotteryWinners(lottery_params, params);
+    } else { 
+        total_winners = pog::ComputeTotalInviteLotteryWinners(height, lottery_params, params);
+    }
 
     if (total_winners == 0) {
         return true;


### PR DESCRIPTION
The number of airdropped invites was half of what was expected because it didn't factor in mined invites.