### PR TITLE
provides positive integer for versionBits

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -711,6 +711,11 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("capabilities", aCaps));
+
+    // resolves -ve overflow
+    Consensus::DeploymentPos pos = Consensus::DeploymentPos();
+    pblock->nVersion &= ~VersionBitsMask(consensusParams, pos);
+
     result.push_back(Pair("version", pblock->nVersion));
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));


### PR DESCRIPTION
Resolves https://github.com/meritlabs/merit/issues/392 ('RPC getblocktemplate returns version: -1476395008')