### PR TITLE
Check for duplicate inputs during block check.

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -153,7 +153,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
-bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs)
+bool CheckTransaction(const CTransaction& tx, CValidationState &state)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
@@ -178,13 +178,11 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
     }
 
     // Check for duplicate inputs - note that this check is slow so we skip it in CheckBlock
-    if (fCheckDuplicateInputs) {
-        std::set<COutPoint> vInOutPoints;
-        for (const auto& txin : tx.vin)
-        {
-            if (!vInOutPoints.insert(txin.prevout).second)
-                return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
-        }
+    std::set<COutPoint> vInOutPoints;
+    for (const auto& txin : tx.vin)
+    {
+        if (!vInOutPoints.insert(txin.prevout).second)
+            return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
     }
 
     if (tx.IsCoinBase())

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -26,7 +26,7 @@ using ConfirmationSet = std::set<uint160>;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state);
 
 namespace Consensus
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3730,17 +3730,6 @@ bool ValidateInvites(
                     "Invite transaction has wrong version");
         }
 
-        if (!CheckTransaction(*inv, state, false)) {
-            return state.Invalid(
-                    false,
-                    state.GetRejectCode(),
-                    state.GetRejectReason(),
-                    strprintf(
-                        "Invite check failed (inv hash %s) %s",
-                        inv->GetHash().ToString(),
-                        state.GetDebugMessage()));
-        }
-
         //Only the first invite can be a coinbase
         if (!first && inv->IsCoinBase()) {
             return state.DoS(
@@ -5722,13 +5711,13 @@ bool CheckBlock(
 
     // Check transactions
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state, false))
+        if (!CheckTransaction(*tx, state))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 
     // Check invites
     for (const auto& invite_tx : block.invites)
-        if (!CheckTransaction(*invite_tx, state, false))
+        if (!CheckTransaction(*invite_tx, state))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Invite transaction check failed (tx hash %s) %s", invite_tx->GetHash().ToString(), state.GetDebugMessage()));
 


### PR DESCRIPTION
This is a downstream fix from Bitcoin. Bad actors could create a block
with duplicate inputs and crash nodes.

The relevant bitcoin change is here: https://github.com/bitcoin/bitcoin/pull/14249